### PR TITLE
v1.7.0: Update to Create 6.0.11 + simplified-overlay tank fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-03
+### Changed
+- **Updated to Create 6.0.11**: Bumped Create `6.0.6-98` → `6.0.11-292` and refreshed the rest of the platform — NeoForge `21.1.206` → `21.1.233`, Ponder `1.0.59` → `1.0.69`, Flywheel `1.0.4` → `1.0.6`, Registrate `+62` → `+67`, JEI `19.22.1.316` → `19.27.0.340`
+- **Create dependency now uses the full jar**: Create stopped publishing the `:slim` classifier at 6.0.11, so the build depends on the full jar (still `transitive = false`). No change to the shipped mod.
+
 ## [1.6.1] - 2026-06-03
 ### Fixed
 - **Config Crash**: Prevent the "trying to get config values before these are loaded to memory" crash by guarding all config reads and writes behind a load check, falling back to default values until the config is loaded (reported on CurseForge)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.7.0] - 2026-06-03
+### Fixed
+- **Held non-tank items no longer appear in the simplified overlay**: previously any item in your main hand (e.g. bone meal) was drawn next to the tank. The held item is now only shown when it is itself a tank.
+- **Empty tanks now display**: a worn tank with zero fuel and water no longer disappears. Tank capability is detected by item identity (known Create: Stuff 'N Additions items) as well as by stored contents, so empty/freshly-crafted tanks are still recognised.
+- **Fixed water-capability detection**: `isHoldingWaterCapableItem` was mistakenly checking fuel capability instead of water.
+- **Robust single/dual layout**: the overlay now picks its layout based on which slot actually holds a tank, avoiding a phantom empty tank when only a held item is a tank.
+
 ### Changed
 - **Updated to Create 6.0.11**: Bumped Create `6.0.6-98` → `6.0.11-292` and refreshed the rest of the platform — NeoForge `21.1.206` → `21.1.233`, Ponder `1.0.59` → `1.0.85`, Flywheel `1.0.4` → `1.0.6`, Registrate `+62` → `+67`, JEI `19.22.1.316` → `19.27.0.340`
 - **Create dependency now uses the full jar**: Create stopped publishing the `:slim` classifier at 6.0.11, so the build depends on the full jar (still `transitive = false`). No change to the shipped mod.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0] - 2026-06-03
 ### Changed
-- **Updated to Create 6.0.11**: Bumped Create `6.0.6-98` → `6.0.11-292` and refreshed the rest of the platform — NeoForge `21.1.206` → `21.1.233`, Ponder `1.0.59` → `1.0.69`, Flywheel `1.0.4` → `1.0.6`, Registrate `+62` → `+67`, JEI `19.22.1.316` → `19.27.0.340`
+- **Updated to Create 6.0.11**: Bumped Create `6.0.6-98` → `6.0.11-292` and refreshed the rest of the platform — NeoForge `21.1.206` → `21.1.233`, Ponder `1.0.59` → `1.0.85`, Flywheel `1.0.4` → `1.0.6`, Registrate `+62` → `+67`, JEI `19.22.1.316` → `19.27.0.340`
 - **Create dependency now uses the full jar**: Create stopped publishing the `:slim` classifier at 6.0.11, so the build depends on the full jar (still `transitive = false`). No change to the shipped mod.
+- **Ponder Maven coordinate change**: Create 6.0.10+ requires Ponder `1.0.82+`, which is published under the new `net.createmod.ponder:ponder-neoforge` artifact (the old `Ponder-NeoForge-1.21.1` artifact stopped at `1.0.69`). Updated the dependency accordingly.
 
 ## [1.6.1] - 2026-06-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0] - 2026-06-03
 ### Fixed
+- **Overlay mode now persists across restarts**: toggling simplified/detailed mode (and the overlay on/off) is now saved to the config file. Previously the change only applied in-memory and reset to the default on the next launch.
 - **Held non-tank items no longer appear in the simplified overlay**: previously any item in your main hand (e.g. bone meal) was drawn next to the tank. The held item is now only shown when it is itself a tank.
 - **Empty tanks now display**: a worn tank with zero fuel and water no longer disappears. Tank capability is detected by item identity (known Create: Stuff 'N Additions items) as well as by stored contents, so empty/freshly-crafted tanks are still recognised.
 - **Fixed water-capability detection**: `isHoldingWaterCapableItem` was mistakenly checking fuel capability instead of water.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ staying current on 1.21.1 or backporting to 1.20.1 (see Roadmap). Do not attempt
 
 ### Dependencies (`gradle.properties`)
 
-- `create_version = 6.0.6-98` — from `maven.createmod.net`, `:slim` classifier, `transitive = false`
+- `create_version = 6.0.11-292` — from `maven.createmod.net`, full jar, `transitive = false` (the `:slim` classifier was dropped by Create at 6.0.11)
 - `ponder_version = 1.0.59`
 - `flywheel_version = 1.0.4` — API `compileOnly` + `neoforge` `runtimeOnly`
 - `registrate_version = MC1.21-1.3.0+62` — from `maven.ithundxr.dev/snapshots`
@@ -143,7 +143,7 @@ the IntelliJ run-config dialog — the generated config can be overwritten on Gr
 - `org.gradle.configuration-cache=true` is on; if it misbehaves after a version/plugin bump,
   run with `--no-configuration-cache` or delete `.gradle/configuration-cache`.
 - On a fresh clone: `chmod +x gradlew`.
-- Create dependency uses the `:slim` classifier with `transitive = false` — don't "fix" that.
+- Create dependency uses `transitive = false` (we declare Ponder/Flywheel/Registrate explicitly) — don't "fix" that. Create published a `:slim` classifier through 6.0.10 but **dropped it at 6.0.11**, so from 6.0.11+ we depend on the full jar (no `:slim`).
 - Build output jar: `build/libs/cfwinfo-<version>.jar`. Bump `mod_version` before building.
 - There is a GitHub Actions workflow under `.github/workflows` and release notes in
   `docs/releases`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,10 @@ staying current on 1.21.1 or backporting to 1.20.1 (see Roadmap). Do not attempt
 ### Dependencies (`gradle.properties`)
 
 - `create_version = 6.0.11-292` — from `maven.createmod.net`, full jar, `transitive = false` (the `:slim` classifier was dropped by Create at 6.0.11)
-- `ponder_version = 1.0.59`
-- `flywheel_version = 1.0.4` — API `compileOnly` + `neoforge` `runtimeOnly`
-- `registrate_version = MC1.21-1.3.0+62` — from `maven.ithundxr.dev/snapshots`
-- `jei_version = 19.22.1.316` — `compileOnly` API + `localRuntime` full
+- `ponder_version = 1.0.85+mc1.21.1` — **note the artifact moved**: use `net.createmod.ponder:ponder-neoforge` (MC encoded in version), NOT the old `Ponder-NeoForge-1.21.1` (which stopped at 1.0.69). Create 6.0.10+ requires Ponder 1.0.82+.
+- `flywheel_version = 1.0.6` — API `compileOnly` + `neoforge` `runtimeOnly`
+- `registrate_version = MC1.21-1.3.0+67` — from `maven.ithundxr.dev/snapshots`
+- `jei_version = 19.27.0.340` — `compileOnly` API + `localRuntime` full
 - **Create Stuff 'N Additions** — `curse.maven:create-stuff-additions-466792:6448012` (Curse Maven; bump by replacing the trailing file id)
 
 Repositories: `maven.createmod.net`, `maven.ithundxr.dev/snapshots`, `cursemaven.com`,

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,10 @@ dependencies {
     // full jar instead. transitive = false keeps Create's own POM dependencies off our classpath;
     // we declare the ones we actually need (Ponder, Flywheel, Registrate) explicitly below.
     implementation("com.simibubi.create:create-${minecraft_version}:${create_version}") { transitive = false }
-    implementation("net.createmod.ponder:Ponder-NeoForge-${minecraft_version}:${ponder_version}")
+    // Ponder moved Maven coordinates around 1.0.79: the old 'Ponder-NeoForge-<mc>' artifact
+    // stopped at 1.0.69, while Create 6.0.10+ requires 1.0.82+. Newer versions live under
+    // 'ponder-neoforge' with the MC version encoded in the version string (e.g. 1.0.85+mc1.21.1).
+    implementation("net.createmod.ponder:ponder-neoforge:${ponder_version}")
     compileOnly("dev.engine-room.flywheel:flywheel-neoforge-api-${minecraft_version}:${flywheel_version}")
     runtimeOnly("dev.engine-room.flywheel:flywheel-neoforge-${minecraft_version}:${flywheel_version}")
     implementation("com.tterrag.registrate:Registrate:${registrate_version}")

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,10 @@ dependencies {
     localRuntime "mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}"
 
     // Create
-    implementation("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
+    // Create stopped publishing the ':slim' classifier from 6.0.11 onward, so we depend on the
+    // full jar instead. transitive = false keeps Create's own POM dependencies off our classpath;
+    // we declare the ones we actually need (Ponder, Flywheel, Registrate) explicitly below.
+    implementation("com.simibubi.create:create-${minecraft_version}:${create_version}") { transitive = false }
     implementation("net.createmod.ponder:Ponder-NeoForge-${minecraft_version}:${ponder_version}")
     compileOnly("dev.engine-room.flywheel:flywheel-neoforge-api-${minecraft_version}:${flywheel_version}")
     runtimeOnly("dev.engine-room.flywheel:flywheel-neoforge-${minecraft_version}:${flywheel_version}")

--- a/docs/releases/v1.7.0.md
+++ b/docs/releases/v1.7.0.md
@@ -1,0 +1,38 @@
+# 🔧 Release v1.7.0 - Updated for Create 6.0.11
+
+> **Maintenance**: Rebuilt against the latest Create and platform dependencies on Minecraft 1.21.1.
+
+## 🔄 What Changed
+
+This release brings the mod in line with the current Create release line. There are no new features and no config changes — it's a compatibility refresh so the overlay keeps working smoothly on up-to-date packs.
+
+### ⬆️ Dependency Updates
+| Dependency | From | To |
+|---|---|---|
+| Create | 6.0.6-98 | **6.0.11-292** |
+| NeoForge | 21.1.206 | 21.1.233 |
+| Ponder | 1.0.59 | 1.0.69 |
+| Flywheel | 1.0.4 | 1.0.6 |
+| Registrate | MC1.21-1.3.0+62 | MC1.21-1.3.0+67 |
+| JEI | 19.22.1.316 | 19.27.0.340 |
+
+### 🛠️ Build Note
+Create stopped publishing its `:slim` classifier at 6.0.11, so the build now depends on the full Create jar (with `transitive = false`). This is a build-only change and does not affect the shipped mod.
+
+## 🔄 Backward Compatibility
+
+✅ **No config changes** — existing config files work unchanged
+✅ **No behaviour changes** — overlay rendering and settings are identical
+✅ **Same Minecraft version** — still Minecraft 1.21.1 / NeoForge
+
+## 📥 Installation
+
+1. Download the latest `.jar` file from this release
+2. Place it in your `mods` folder
+3. Launch Minecraft with NeoForge and an up-to-date Create
+
+---
+
+**Requirements**: Minecraft 1.21.1 | NeoForge 21.1.233+ | Create 6.0.11+
+
+**Compatibility**: Works with Create: Stuff & Additions and other Create-compatible tank items

--- a/docs/releases/v1.7.0.md
+++ b/docs/releases/v1.7.0.md
@@ -11,13 +11,14 @@ This release brings the mod in line with the current Create release line. There 
 |---|---|---|
 | Create | 6.0.6-98 | **6.0.11-292** |
 | NeoForge | 21.1.206 | 21.1.233 |
-| Ponder | 1.0.59 | 1.0.69 |
+| Ponder | 1.0.59 | 1.0.85 |
 | Flywheel | 1.0.4 | 1.0.6 |
 | Registrate | MC1.21-1.3.0+62 | MC1.21-1.3.0+67 |
 | JEI | 19.22.1.316 | 19.27.0.340 |
 
-### 🛠️ Build Note
-Create stopped publishing its `:slim` classifier at 6.0.11, so the build now depends on the full Create jar (with `transitive = false`). This is a build-only change and does not affect the shipped mod.
+### 🛠️ Build Notes
+- Create stopped publishing its `:slim` classifier at 6.0.11, so the build now depends on the full Create jar (with `transitive = false`). This is a build-only change and does not affect the shipped mod.
+- Ponder moved Maven coordinates: Create 6.0.10+ requires Ponder `1.0.82+`, now published under `net.createmod.ponder:ponder-neoforge` (the old `Ponder-NeoForge-1.21.1` artifact stopped at `1.0.69`).
 
 ## 🔄 Backward Compatibility
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ mod_description=This mod will render Tank fuel and water levels on the HUD so yo
 
 # Create
 create_version = 6.0.11-292
-ponder_version = 1.0.69
+ponder_version = 1.0.85+mc1.21.1
 flywheel_version = 1.0.6
 registrate_version = MC1.21-1.3.0+67
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1]
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=21.1.206
+neo_version=21.1.233
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[1,)
 
@@ -32,7 +32,7 @@ mod_name=Create: Fuel & Water Information
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=1.6.1
+mod_version=1.7.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
@@ -43,10 +43,10 @@ mod_authors=Jopgood
 mod_description=This mod will render Tank fuel and water levels on the HUD so you do not have to keep checking!
 
 # Create
-create_version = 6.0.6-98
-ponder_version = 1.0.59
-flywheel_version = 1.0.4
-registrate_version = MC1.21-1.3.0+62
+create_version = 6.0.11-292
+ponder_version = 1.0.69
+flywheel_version = 1.0.6
+registrate_version = MC1.21-1.3.0+67
 
 # Other
-jei_version = 19.22.1.316
+jei_version = 19.27.0.340

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
@@ -133,17 +133,20 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         int scaledX = (int) (x / scaleFactor);
         int scaledY = (int) (y / scaleFactor);
 
-        // Check if tool item is also a tank
+        // Decide layout based on which slots actually hold a tank, so we never render a phantom
+        // tank for an empty/non-tank slot.
+        boolean chestIsTank = TankDataManager.isWearingFuelCapableItem(player) || TankDataManager.isWearingWaterCapableItem(player);
         boolean toolIsTank = TankDataManager.isHoldingFuelCapableItem(player) || TankDataManager.isHoldingWaterCapableItem(player);
-        
-        if (toolIsTank) {
-            // Render two tank sprites with position-aware layout
-            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem, 
+
+        if (chestIsTank && toolIsTank) {
+            // Both a worn tank and a held tank: render two tank sprites with position-aware layout
+            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem,
                                 tankU, tankV, fuelU, fuelV, waterU, waterV, position);
         } else {
-            // Render single tank sprite with tool item beside
-            renderSingleTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem,
-                                  tankU, tankV, fuelU, fuelV, waterU, waterV, position);
+            // Exactly one tank present (the render() gate guarantees at least one). Show whichever
+            // slot is the tank; the held item is only drawn when it is itself a tank.
+            ItemStack subject = chestIsTank ? tankItem : toolItem;
+            renderSingleTankDisplay(graphics, scaledX, scaledY, subject, position);
         }
         
         graphics.pose().popPose();
@@ -213,31 +216,40 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
     }
     
     private void renderSingleTankDisplay(GuiGraphics graphics, int scaledX, int scaledY,
-                                       ItemStack tankItem, ItemStack toolItem,
-                                       int tankU, int tankV, int fuelU, int fuelV, int waterU, int waterV,
+                                       ItemStack tankItem,
                                        CommonConfig.OverlayPosition position) {
         // Apply right side padding to prevent clipping
-        boolean isRightSide = position == CommonConfig.OverlayPosition.TOP_RIGHT || 
+        boolean isRightSide = position == CommonConfig.OverlayPosition.TOP_RIGHT ||
                              position == CommonConfig.OverlayPosition.BOTTOM_RIGHT;
         float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
         int paddingOffset = isRightSide ? (int)(16 / scaleFactor) : 0;
         int adjustedX = scaledX - paddingOffset;
-        
+
+        // Compute fuel/water frames from the tank we're actually showing (works for an empty tank too).
+        int fuelU = frameU(TankDataManager.getFuelLevel(tankItem));
+        int waterU = frameU(TankDataManager.getWaterLevel(tankItem));
+        int tankU = 0;
+        int tankV = 2 * FRAME_HEIGHT; // tank outline row
+
         // Render single tank sprite
-        renderTankLayers(graphics, adjustedX, scaledY, tankU, tankV, fuelU, fuelV, waterU, waterV);
-        
+        renderTankLayers(graphics, adjustedX, scaledY, tankU, tankV, fuelU, 0, waterU, FRAME_HEIGHT);
+
         // Determine item positioning based on overlay position
-        boolean itemsAbove = position == CommonConfig.OverlayPosition.BOTTOM_LEFT || 
+        boolean itemsAbove = position == CommonConfig.OverlayPosition.BOTTOM_LEFT ||
                             position == CommonConfig.OverlayPosition.BOTTOM_RIGHT;
         int itemY = itemsAbove ? scaledY - 16 : scaledY + 32;
-        
-        // Render tank item 
+
+        // Render only the tank item's icon. The held item is intentionally not drawn here — if the
+        // held item were a tank we'd be in renderDualTankDisplay, so anything else (e.g. bone meal)
+        // is irrelevant and must not appear next to the tank.
         GuiGameElement.of(tankItem).at(adjustedX, itemY, 450).render(graphics);
-        
-        // Render tool item beside tank item (if not empty)
-        if (!toolItem.isEmpty()) {
-            GuiGameElement.of(toolItem).at(adjustedX + 16, itemY, 450).render(graphics);
-        }
+    }
+
+    /** Maps a fuel/water level to its column U offset in the sprite sheet. */
+    private static int frameU(double level) {
+        int frameIndex = ((MAX_LEVEL - (int) Math.round(level)) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
+        frameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, frameIndex));
+        return (frameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
     }
 
     private void renderTankLayers(GuiGraphics graphics, int scaledX, int scaledY, 

--- a/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
+++ b/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
@@ -97,10 +97,16 @@ public class CommonConfig {
      * Writes a config value, but only once the config spec has been loaded. Setting
      * a value before load would throw the same "not loaded" error, so the write is
      * silently skipped until the config is available.
+     *
+     * <p>{@link ModConfigSpec.ConfigValue#set} only updates the in-memory config; it does
+     * not flush to disk, so runtime changes (e.g. toggling simplified mode with a keybind)
+     * would be lost on restart. We call {@link ModConfigSpec#save()} afterwards to persist
+     * the change to the config file.
      */
     private static <T> void safeSet(ModConfigSpec.ConfigValue<T> value, T newValue) {
         if (SPEC.isLoaded()) {
             value.set(newValue);
+            SPEC.save();
         }
     }
 

--- a/src/main/java/com/jopgood/cfwinfo/common/data/TankDataManager.java
+++ b/src/main/java/com/jopgood/cfwinfo/common/data/TankDataManager.java
@@ -1,22 +1,78 @@
 package com.jopgood.cfwinfo.common.data;
 
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 
+import java.util.Set;
+
 public class TankDataManager {
+
+    /** Namespace of Create: Stuff 'N Additions. */
+    private static final String CSA_NAMESPACE = "create_sa";
+
+    /**
+     * Create: Stuff 'N Additions items that can hold fuel. Detection by item identity lets us
+     * recognise a tank even when it is empty — CS&A only writes the "tagFuel"/"tagWater" NBT keys
+     * when there is content, so a freshly crafted or fully drained tank would otherwise look like a
+     * non-tank item. Derived from which item/procedure classes reference "tagFuel" in CS&A.
+     * Update this set if CS&A adds or renames fuel-holding items.
+     */
+    private static final Set<String> FUEL_CAPABLE_ITEMS = Set.of(
+            "andesite_jetpack_chestplate",
+            "brass_jetpack_chestplate",
+            "netherite_jetpack_chestplate",
+            "andesite_exoskeleton_chestplate",
+            "brass_exoskeleton_chestplate",
+            "portable_drill",
+            "small_fueling_tank",
+            "medium_fueling_tank",
+            "large_fueling_tank",
+            "creative_filling_tank",
+            "flamethrower",
+            "grapplin_whisk"
+    );
+
+    /**
+     * Create: Stuff 'N Additions items that can hold water. See {@link #FUEL_CAPABLE_ITEMS} for why
+     * identity detection is used. Derived from which item/procedure classes reference "tagWater".
+     */
+    private static final Set<String> WATER_CAPABLE_ITEMS = Set.of(
+            "brass_jetpack_chestplate",
+            "copper_jetpack_chestplate",
+            "netherite_jetpack_chestplate",
+            "brass_exoskeleton_chestplate",
+            "copper_exoskeleton_chestplate",
+            "portable_drill",
+            "small_filling_tank",
+            "medium_filling_tank",
+            "large_filling_tank",
+            "creative_filling_tank",
+            "block_picker"
+    );
+
+    /** True if the stack is a known CS&A item whose registry path is in {@code knownItems}. */
+    private static boolean isKnownCsaItem(ItemStack itemStack, Set<String> knownItems) {
+        if (itemStack.isEmpty()) return false;
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(itemStack.getItem());
+        return CSA_NAMESPACE.equals(id.getNamespace()) && knownItems.contains(id.getPath());
+    }
 
     public static boolean canItemStoreFuel(ItemStack itemStack) {
         if (itemStack.isEmpty()) return false;
         CustomData customData = itemStack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY);
-        return customData.copyTag().contains("tagFuel");
+        // Tag presence covers items that currently hold fuel; identity covers empty tanks.
+        return customData.copyTag().contains("tagFuel") || isKnownCsaItem(itemStack, FUEL_CAPABLE_ITEMS);
     }
 
     public static boolean canItemStoreWater(ItemStack itemStack) {
         if (itemStack.isEmpty()) return false;
         CustomData customData = itemStack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY);
-        return customData.copyTag().contains("tagWater");
+        // Tag presence covers items that currently hold water; identity covers empty tanks.
+        return customData.copyTag().contains("tagWater") || isKnownCsaItem(itemStack, WATER_CAPABLE_ITEMS);
     }
 
     public static boolean isHoldingFuelCapableItem(Player player) {
@@ -26,7 +82,7 @@ public class TankDataManager {
 
     public static boolean isHoldingWaterCapableItem(Player player) {
         ItemStack tool = player.getMainHandItem();
-        return canItemStoreFuel(tool);
+        return canItemStoreWater(tool);
     }
 
     public static boolean isWearingFuelCapableItem(Player player) {


### PR DESCRIPTION
Targets **v1.7.0**. Two themes: a platform/dependency refresh, and simplified-mode overlay bug fixes reported during testing.

## 1. Dependency refresh (Create 6.0.11)

| Dependency | From | To |
|---|---|---|
| **Create** | 6.0.6-98 | **6.0.11-292** |
| NeoForge | 21.1.206 | 21.1.233 |
| Ponder | 1.0.59 | 1.0.85 |
| Flywheel | 1.0.4 | 1.0.6 |
| Registrate | MC1.21-1.3.0+62 | MC1.21-1.3.0+67 |
| JEI | 19.22.1.316 | 19.27.0.340 |

Two coordinate changes (verified against Create 6.0.11's own metadata):
- **Slim classifier dropped** at 6.0.11 → build now uses the full Create jar (`transitive = false`). Build-only; shipped mod unaffected.
- **Ponder repathed**: Create 6.0.10+ requires Ponder `1.0.82+`, published under the new `net.createmod.ponder:ponder-neoforge` artifact (old `Ponder-NeoForge-1.21.1` stopped at 1.0.69). Now `1.0.85+mc1.21.1`. (Caught a first-launch "requires ponder 1.0.82 or above" crash.)

## 2. Simplified-overlay tank fixes

- **Held non-tank items no longer shown** (bone meal etc. appeared next to the tank).
- **Empty tanks now display** — detection no longer relies solely on the `tagFuel`/`tagWater` NBT (which CS&A only writes when a tank has content); known CS&A tank items are now recognised by registry id too.
- **Fixed water-capability bug** — `isHoldingWaterCapableItem` was checking fuel.
- **Robust single/dual layout** — chooses layout by which slot actually holds a tank.

The CS&A fuel/water item lists are derived from which CS&A item/procedure classes reference each NBT tag (not guessed).

## Testing

- `./gradlew --refresh-dependencies build` passes; in-game launch now loads cleanly and the overlay renders.
- ⚠️ **Overlay fixes need an in-game sanity check** across: worn fueled tank + non-tank held item (no bone meal), worn *empty* tank (still shows), worn tank + held tank (dual), held tank only.

## Follow-ups
- CS&A Curse file id (`6448012`) not bumped here.