### PR TITLE
v1.8.0: Drag-to-position overlay editor + scale slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-03
+### Added
+- **Drag-to-position overlay editor**: a new keybind (default `O`) opens an in-game editor where you can drag the overlay anywhere on screen. The preview matches the live HUD exactly, and the controls hide while dragging for an unobstructed view.
+- **Preset positions in the editor**: Top Left / Top Right / Bottom Left / Bottom Right buttons preview a corner before you commit, instead of applying immediately.
+- **Tank scale slider**: adjust the sprite size (0.5x–5.0x) live in the editor, with a tooltip noting it stacks on top of Minecraft's GUI Scale. The new position and scale are saved together on Save and reverted on Cancel.
+
+### Changed
+- **Unified overlay layout for all positions** (chest tank left, tool tank right, item icons below). Corner positions now account for the full composite size so nothing clips at the screen edge.
+
 ## [1.7.0] - 2026-06-03
 ### Fixed
 - **Overlay mode now persists across restarts**: toggling simplified/detailed mode (and the overlay on/off) is now saved to the config file. Previously the change only applied in-memory and reset to the default on the next launch.

--- a/docs/releases/v1.8.0.md
+++ b/docs/releases/v1.8.0.md
@@ -1,0 +1,46 @@
+# 🎯 Release v1.8.0 - Drag-to-Position Overlay
+
+> **New Feature**: Put the overlay wherever you want it, and size it to taste — without touching a config file.
+
+## ✨ What's New
+
+### 🖱️ Drag-to-Position Editor
+- Press the **Edit Overlay Position** keybind (default `O`) in-world to open the editor.
+- **Drag** the overlay anywhere on screen. The preview is the real overlay, so what you see is exactly what you get on the HUD.
+- The controls **hide while you drag** for a clean, unobstructed view, and reappear when you release.
+
+### 📍 Preset Positions
+- **Top Left / Top Right / Bottom Left / Bottom Right** buttons let you preview a corner before committing.
+- Presets re-anchor automatically if your resolution or GUI scale changes; a dragged position is saved as exact coordinates.
+
+### 📏 Tank Scale Slider
+- Adjust the tank sprite size from **0.5x to 5.0x** live in the editor.
+- A tooltip clarifies that the overlay already scales with Minecraft's **GUI Scale**; this is an extra multiplier on top of that.
+- Position and scale are saved together on **Save**, or reverted on **Cancel**.
+
+## 🔧 Under the Hood
+- The overlay now uses one consistent layout for every position (chest tank left, tool tank right, item icons below), with corner positions sized so the overlay never clips at the screen edge.
+
+## 🔄 Backward Compatibility
+
+✅ **Existing configs keep working** — defaults are unchanged; the new options are opt-in.
+✅ **Same Minecraft version** — still Minecraft 1.21.1 / NeoForge.
+
+## 🎮 How to Use
+
+1. Equip a Create tank item and enable the overlay (simplified mode shows the tank sprites).
+2. Press `O` in-world to open the editor.
+3. Drag the overlay, pick a preset, and/or adjust the scale slider.
+4. Hit **Save**.
+
+## 📥 Installation
+
+1. Download the latest `.jar` file from this release
+2. Place it in your `mods` folder
+3. Launch Minecraft with NeoForge
+
+---
+
+**Requirements**: Minecraft 1.21.1 | NeoForge 21.1.233+ | Create 6.0.11+
+
+**Compatibility**: Works with Create: Stuff & Additions and other Create-compatible tank items

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ mod_name=Create: Fuel & Water Information
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=1.7.0
+mod_version=1.8.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/jopgood/cfwinfo/client/ClientSetup.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/ClientSetup.java
@@ -15,6 +15,9 @@ import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterGuiLayersEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 
+import com.jopgood.cfwinfo.client.gui.OverlayEditScreen;
+
+import static com.jopgood.cfwinfo.client.KeyBinding.EDIT_OVERLAY;
 import static com.jopgood.cfwinfo.client.KeyBinding.TOGGLE_OVERLAY;
 import static com.jopgood.cfwinfo.client.KeyBinding.TOGGLE_SIMPLIFIED;
 
@@ -27,6 +30,7 @@ public class ClientSetup {
     public static void registerBindings(RegisterKeyMappingsEvent event) {
         event.register(TOGGLE_OVERLAY.get());
         event.register(TOGGLE_SIMPLIFIED.get());
+        event.register(EDIT_OVERLAY.get());
     }
 
 
@@ -56,6 +60,13 @@ public class ClientSetup {
                 mc.player.sendSystemMessage(Component.literal(
                         "Simplified Mode: " + (!simple ? "On" : "Off")
                 ));
+            }
+        }
+
+        while (EDIT_OVERLAY.get().consumeClick()) {
+            // Open the drag-to-position editor (only when in-world with no screen already open)
+            if (mc.player != null && mc.screen == null) {
+                mc.setScreen(new OverlayEditScreen());
             }
         }
     }

--- a/src/main/java/com/jopgood/cfwinfo/client/KeyBinding.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/KeyBinding.java
@@ -19,4 +19,11 @@ public class KeyBinding {
             GLFW.GLFW_KEY_P,
             "key.categories.cfwinfo"
     ));
+
+    public static final Lazy<KeyMapping> EDIT_OVERLAY = Lazy.of(() -> new KeyMapping(
+            "key.cfwinfo.edit_overlay",
+            InputConstants.Type.KEYSYM,
+            GLFW.GLFW_KEY_O,
+            "key.categories.cfwinfo"
+    ));
 }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
@@ -1,0 +1,48 @@
+package com.jopgood.cfwinfo.client.gui;
+
+import com.jopgood.cfwinfo.common.config.CommonConfig;
+import com.jopgood.cfwinfo.common.config.CommonConfig.OverlayPosition;
+
+/**
+ * Single source of truth for where the overlay is anchored on screen.
+ *
+ * <p>Everything works in GUI-scaled pixels — the same coordinate space that
+ * {@code GuiGraphics#guiWidth()}/{@code guiHeight()} and {@code Screen} mouse events use. Because
+ * the live HUD and the overlay editor both resolve their anchor through here (and render through
+ * the same code), a position chosen in the editor renders in exactly the same place on the HUD —
+ * no drift between "where you dropped it" and "where it shows up".
+ */
+public final class OverlayAnchor {
+
+    /** Distance from the screen edge for the preset corner positions, in GUI pixels. */
+    public static final int MARGIN = 10;
+
+    private OverlayAnchor() {}
+
+    /**
+     * Resolves the top-left anchor of the tank sprite for the simplified overlay.
+     *
+     * @param position the configured overlay position
+     * @param guiW     GUI-scaled screen width
+     * @param guiH     GUI-scaled screen height
+     * @param renderW  rendered width of a single tank sprite (FRAME_WIDTH * scale)
+     * @param renderH  rendered height of a single tank sprite (FRAME_HEIGHT * scale)
+     * @return {@code [x, y]} top-left anchor in GUI pixels
+     */
+    public static int[] resolveSprite(OverlayPosition position, int guiW, int guiH, int renderW, int renderH) {
+        return switch (position) {
+            case TOP_LEFT -> new int[]{MARGIN, MARGIN};
+            case TOP_RIGHT -> new int[]{guiW - renderW - MARGIN, MARGIN};
+            case BOTTOM_LEFT -> new int[]{MARGIN, guiH - renderH - MARGIN};
+            case BOTTOM_RIGHT -> new int[]{guiW - renderW - MARGIN, guiH - renderH - MARGIN};
+            case CUSTOM -> new int[]{
+                    clamp(CommonConfig.getCustomX(), 0, Math.max(0, guiW - renderW)),
+                    clamp(CommonConfig.getCustomY(), 0, Math.max(0, guiH - renderH))
+            };
+        };
+    }
+
+    public static int clamp(int value, int lo, int hi) {
+        return Math.max(lo, Math.min(hi, value));
+    }
+}

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
@@ -4,13 +4,9 @@ import com.jopgood.cfwinfo.common.config.CommonConfig;
 import com.jopgood.cfwinfo.common.config.CommonConfig.OverlayPosition;
 
 /**
- * Single source of truth for where the overlay is anchored on screen.
- *
- * <p>Everything works in GUI-scaled pixels — the same coordinate space that
- * {@code GuiGraphics#guiWidth()}/{@code guiHeight()} and {@code Screen} mouse events use. Because
- * the live HUD and the overlay editor both resolve their anchor through here (and render through
- * the same code), a position chosen in the editor renders in exactly the same place on the HUD —
- * no drift between "where you dropped it" and "where it shows up".
+ * Resolves where the overlay is anchored on screen, in GUI-scaled pixels — the coordinate space
+ * shared by {@code GuiGraphics#guiWidth()}/{@code guiHeight()} and {@code Screen} mouse events.
+ * The HUD and the editor both anchor through here so a position chosen in the editor matches the HUD.
  */
 public final class OverlayAnchor {
 

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
@@ -20,24 +20,24 @@ public final class OverlayAnchor {
     private OverlayAnchor() {}
 
     /**
-     * Resolves the top-left anchor of the tank sprite for the simplified overlay.
+     * Resolves the top-left anchor of the simplified overlay composite.
      *
      * @param position the configured overlay position
      * @param guiW     GUI-scaled screen width
      * @param guiH     GUI-scaled screen height
-     * @param renderW  rendered width of a single tank sprite (FRAME_WIDTH * scale)
-     * @param renderH  rendered height of a single tank sprite (FRAME_HEIGHT * scale)
+     * @param contentW rendered width of the whole composite in GUI pixels
+     * @param contentH rendered height of the whole composite in GUI pixels
      * @return {@code [x, y]} top-left anchor in GUI pixels
      */
-    public static int[] resolveSprite(OverlayPosition position, int guiW, int guiH, int renderW, int renderH) {
+    public static int[] resolveSprite(OverlayPosition position, int guiW, int guiH, int contentW, int contentH) {
         return switch (position) {
             case TOP_LEFT -> new int[]{MARGIN, MARGIN};
-            case TOP_RIGHT -> new int[]{guiW - renderW - MARGIN, MARGIN};
-            case BOTTOM_LEFT -> new int[]{MARGIN, guiH - renderH - MARGIN};
-            case BOTTOM_RIGHT -> new int[]{guiW - renderW - MARGIN, guiH - renderH - MARGIN};
+            case TOP_RIGHT -> new int[]{guiW - contentW - MARGIN, MARGIN};
+            case BOTTOM_LEFT -> new int[]{MARGIN, guiH - contentH - MARGIN};
+            case BOTTOM_RIGHT -> new int[]{guiW - contentW - MARGIN, guiH - contentH - MARGIN};
             case CUSTOM -> new int[]{
-                    clamp(CommonConfig.getCustomX(), 0, Math.max(0, guiW - renderW)),
-                    clamp(CommonConfig.getCustomY(), 0, Math.max(0, guiH - renderH))
+                    clamp(CommonConfig.getCustomX(), 0, Math.max(0, guiW - contentW)),
+                    clamp(CommonConfig.getCustomY(), 0, Math.max(0, guiH - contentH))
             };
         };
     }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
@@ -128,22 +128,15 @@ public class OverlayEditScreen extends Screen {
         onClose();
     }
 
+    /** Item icons render at z=450; lift the controls above that so they always sit on top. */
+    private static final int CONTROL_LAYER_Z = 500;
+
     @Override
     public void render(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
         // Light dim so the UI is readable but the world (and where the overlay sits on it) stays visible.
         renderBackground(graphics, mouseX, mouseY, partialTick);
 
-        // Title + instructions.
-        graphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 0xFFFFFFFF);
-        graphics.drawCenteredString(this.font, INSTRUCTION, this.width / 2, 22, 0xFFB0B0B0);
-
-        // Widgets (buttons + slider).
-        for (Renderable renderable : this.renderables) {
-            renderable.render(graphics, mouseX, mouseY, partialTick);
-        }
-
-        // Preview LAST so the whole composite (flat tank sprites + depth-tested item icons) draws
-        // consistently on top of the widgets. Buttons remain clickable (see mouseClicked).
+        // Preview behind the controls.
         Player player = this.minecraft != null ? this.minecraft.player : null;
         if (player != null) {
             int w = TankSpriteOverlay.compositeWidthPx(player);
@@ -154,6 +147,16 @@ public class OverlayEditScreen extends Screen {
 
             previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player);
         }
+
+        // Controls above the preview (including the depth-tested item icons).
+        graphics.pose().pushPose();
+        graphics.pose().translate(0, 0, CONTROL_LAYER_Z);
+        graphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 0xFFFFFFFF);
+        graphics.drawCenteredString(this.font, INSTRUCTION, this.width / 2, 22, 0xFFB0B0B0);
+        for (Renderable renderable : this.renderables) {
+            renderable.render(graphics, mouseX, mouseY, partialTick);
+        }
+        graphics.pose().popPose();
     }
 
     /** Background: a light dim rather than the default blur, so the world is visible while editing. */
@@ -164,7 +167,7 @@ public class OverlayEditScreen extends Screen {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        // Let widgets (buttons/slider) win first, so a preview drawn over them stays clickable.
+        // Controls render on top, so let them handle the click before starting a drag.
         if (super.mouseClicked(mouseX, mouseY, button)) {
             return true;
         }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
@@ -1,0 +1,173 @@
+package com.jopgood.cfwinfo.client.gui;
+
+import com.jopgood.cfwinfo.common.config.CommonConfig;
+import com.jopgood.cfwinfo.common.config.CommonConfig.OverlayPosition;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * In-game editor for freely positioning the overlay by dragging it.
+ *
+ * <p>The preview is drawn by the live {@link TankSpriteOverlay#renderCompositeAt} method at the same
+ * anchor the HUD would use, so it is WYSIWYG — what you drop is exactly what renders. Dragging keeps
+ * the cursor's offset within the sprite (a "grab offset"), so picking the sprite up anywhere doesn't
+ * snap it under the cursor, and the saved anchor matches the previewed one precisely.
+ */
+public class OverlayEditScreen extends Screen {
+
+    private static final Component INSTRUCTION =
+            Component.literal("Drag the overlay to position it, then Save. Or pick a preset.");
+
+    private final TankSpriteOverlay previewOverlay = new TankSpriteOverlay();
+
+    // Working anchor (top-left of the tank sprite) in GUI pixels.
+    private int anchorX;
+    private int anchorY;
+
+    // Drag state.
+    private boolean dragging = false;
+    private int grabOffsetX;
+    private int grabOffsetY;
+
+    public OverlayEditScreen() {
+        super(Component.literal("Overlay Position"));
+    }
+
+    @Override
+    protected void init() {
+        // Seed the working anchor from where the overlay currently renders, so it doesn't jump.
+        int[] anchor = TankSpriteOverlay.currentAnchor(this.width, this.height);
+        anchorX = anchor[0];
+        anchorY = anchor[1];
+        clampAnchor();
+
+        int cx = this.width / 2;
+        int bottom = this.height - 28;
+
+        // Preset reset buttons (row above the action row).
+        int presetY = bottom - 24;
+        int presetW = 78;
+        int gap = 4;
+        int rowWidth = presetW * 4 + gap * 3;
+        int startX = cx - rowWidth / 2;
+        addRenderableWidget(Button.builder(Component.literal("Top Left"), b -> applyPreset(OverlayPosition.TOP_LEFT))
+                .bounds(startX, presetY, presetW, 20).build());
+        addRenderableWidget(Button.builder(Component.literal("Top Right"), b -> applyPreset(OverlayPosition.TOP_RIGHT))
+                .bounds(startX + (presetW + gap), presetY, presetW, 20).build());
+        addRenderableWidget(Button.builder(Component.literal("Bottom Left"), b -> applyPreset(OverlayPosition.BOTTOM_LEFT))
+                .bounds(startX + 2 * (presetW + gap), presetY, presetW, 20).build());
+        addRenderableWidget(Button.builder(Component.literal("Bottom Right"), b -> applyPreset(OverlayPosition.BOTTOM_RIGHT))
+                .bounds(startX + 3 * (presetW + gap), presetY, presetW, 20).build());
+
+        // Action row: Save / Cancel.
+        addRenderableWidget(Button.builder(Component.literal("Save"), b -> save())
+                .bounds(cx - 104, bottom, 100, 20).build());
+        addRenderableWidget(Button.builder(Component.literal("Cancel"), b -> onClose())
+                .bounds(cx + 4, bottom, 100, 20).build());
+    }
+
+    /** Switches to a preset position and stores it immediately, then closes. */
+    private void applyPreset(OverlayPosition position) {
+        CommonConfig.setOverlayPosition(position);
+        onClose();
+    }
+
+    /** Persists the dragged position as a CUSTOM anchor and closes. */
+    private void save() {
+        CommonConfig.setCustomPosition(anchorX, anchorY);
+        onClose();
+    }
+
+    @Override
+    public void render(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        // Light dim so the UI is readable but the world (and where the overlay sits on it) stays visible.
+        renderBackground(graphics, mouseX, mouseY, partialTick);
+
+        Player player = this.minecraft != null ? this.minecraft.player : null;
+        if (player != null) {
+            int w = TankSpriteOverlay.compositeWidthPx(player);
+            int h = TankSpriteOverlay.compositeHeightPx();
+
+            // Highlight the draggable region.
+            int border = dragging ? 0xFFFFE066 : 0x80FFFFFF;
+            graphics.renderOutline(anchorX - 1, anchorY - 1, w + 2, h + 2, border);
+
+            // Live preview using the exact HUD rendering path (CUSTOM layout: items below, no padding).
+            previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player, OverlayPosition.CUSTOM);
+        }
+
+        // Title + instructions.
+        graphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 0xFFFFFFFF);
+        graphics.drawCenteredString(this.font, INSTRUCTION, this.width / 2, 22, 0xFFB0B0B0);
+
+        // Buttons on top of everything.
+        for (Renderable renderable : this.renderables) {
+            renderable.render(graphics, mouseX, mouseY, partialTick);
+        }
+    }
+
+    /** Background: a light dim rather than the default blur, so the world is visible while editing. */
+    @Override
+    public void renderBackground(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        graphics.fill(0, 0, this.width, this.height, 0x40000000);
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (button == 0 && this.minecraft != null && this.minecraft.player != null && isInsideOverlay(mouseX, mouseY)) {
+            dragging = true;
+            grabOffsetX = (int) Math.round(mouseX) - anchorX;
+            grabOffsetY = (int) Math.round(mouseY) - anchorY;
+            return true;
+        }
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
+        if (dragging) {
+            anchorX = (int) Math.round(mouseX) - grabOffsetX;
+            anchorY = (int) Math.round(mouseY) - grabOffsetY;
+            clampAnchor();
+            return true;
+        }
+        return super.mouseDragged(mouseX, mouseY, button, dragX, dragY);
+    }
+
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        if (button == 0 && dragging) {
+            dragging = false;
+            return true;
+        }
+        return super.mouseReleased(mouseX, mouseY, button);
+    }
+
+    private boolean isInsideOverlay(double mouseX, double mouseY) {
+        Player player = this.minecraft != null ? this.minecraft.player : null;
+        if (player == null) return false;
+        int w = TankSpriteOverlay.compositeWidthPx(player);
+        int h = TankSpriteOverlay.compositeHeightPx();
+        return mouseX >= anchorX && mouseX <= anchorX + w && mouseY >= anchorY && mouseY <= anchorY + h;
+    }
+
+    /** Keeps the composite fully on screen. */
+    private void clampAnchor() {
+        Player player = this.minecraft != null ? this.minecraft.player : null;
+        int w = player != null ? TankSpriteOverlay.compositeWidthPx(player) : 0;
+        int h = TankSpriteOverlay.compositeHeightPx();
+        anchorX = OverlayAnchor.clamp(anchorX, 0, Math.max(0, this.width - w));
+        anchorY = OverlayAnchor.clamp(anchorY, 0, Math.max(0, this.height - h));
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        // Keep the world rendering so the player can see the overlay in context.
+        return false;
+    }
+}

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
@@ -128,15 +128,17 @@ public class OverlayEditScreen extends Screen {
         onClose();
     }
 
-    /** Item icons render at z=450; lift the controls above that so they always sit on top. */
-    private static final int CONTROL_LAYER_Z = 500;
+    private static final Component DRAG_HINT = Component.literal("Release to place the overlay.");
+
+    /** Low item-icon z so a resting preview stays behind the controls (during a drag they're hidden). */
+    private static final int PREVIEW_ITEM_Z = 0;
 
     @Override
     public void render(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
         // Light dim so the UI is readable but the world (and where the overlay sits on it) stays visible.
         renderBackground(graphics, mouseX, mouseY, partialTick);
 
-        // Preview behind the controls.
+        // The overlay preview.
         Player player = this.minecraft != null ? this.minecraft.player : null;
         if (player != null) {
             int w = TankSpriteOverlay.compositeWidthPx(player);
@@ -145,18 +147,19 @@ public class OverlayEditScreen extends Screen {
             int border = dragging ? 0xFFFFE066 : 0x80FFFFFF;
             graphics.renderOutline(anchorX - 1, anchorY - 1, w + 2, h + 2, border);
 
-            previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player);
+            previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player, PREVIEW_ITEM_Z);
         }
 
-        // Controls above the preview (including the depth-tested item icons).
-        graphics.pose().pushPose();
-        graphics.pose().translate(0, 0, CONTROL_LAYER_Z);
-        graphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 0xFFFFFFFF);
-        graphics.drawCenteredString(this.font, INSTRUCTION, this.width / 2, 22, 0xFFB0B0B0);
-        for (Renderable renderable : this.renderables) {
-            renderable.render(graphics, mouseX, mouseY, partialTick);
+        if (dragging) {
+            // Hide the controls while dragging so the preview is never obscured by (or overlapping) them.
+            graphics.drawCenteredString(this.font, DRAG_HINT, this.width / 2, 8, 0xFFFFFFFF);
+        } else {
+            graphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 0xFFFFFFFF);
+            graphics.drawCenteredString(this.font, INSTRUCTION, this.width / 2, 22, 0xFFB0B0B0);
+            for (Renderable renderable : this.renderables) {
+                renderable.render(graphics, mouseX, mouseY, partialTick);
+            }
         }
-        graphics.pose().popPose();
     }
 
     /** Background: a light dim rather than the default blur, so the world is visible while editing. */

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
@@ -3,25 +3,34 @@ package com.jopgood.cfwinfo.client.gui;
 import com.jopgood.cfwinfo.common.config.CommonConfig;
 import com.jopgood.cfwinfo.common.config.CommonConfig.OverlayPosition;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractSliderButton;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * In-game editor for freely positioning the overlay by dragging it.
+ * In-game editor for freely positioning and sizing the overlay.
  *
  * <p>The preview is drawn by the live {@link TankSpriteOverlay#renderCompositeAt} method at the same
  * anchor the HUD would use, so it is WYSIWYG — what you drop is exactly what renders. Dragging keeps
  * the cursor's offset within the sprite (a "grab offset"), so picking the sprite up anywhere doesn't
  * snap it under the cursor, and the saved anchor matches the previewed one precisely.
+ *
+ * <p>The scale slider previews live by writing the scale to the config in memory only; the value is
+ * persisted when the editor commits (Save / a preset button) and reverted if the editor is cancelled.
  */
 public class OverlayEditScreen extends Screen {
 
     private static final Component INSTRUCTION =
             Component.literal("Drag the overlay to position it, then Save. Or pick a preset.");
+
+    private static final double MIN_SCALE = 0.5;
+    private static final double MAX_SCALE = 5.0;
 
     private final TankSpriteOverlay previewOverlay = new TankSpriteOverlay();
 
@@ -34,12 +43,20 @@ public class OverlayEditScreen extends Screen {
     private int grabOffsetX;
     private int grabOffsetY;
 
+    // Scale preview/commit state.
+    private double originalScale;
+    private boolean committed = false;
+
     public OverlayEditScreen() {
         super(Component.literal("Overlay Position"));
     }
 
     @Override
     protected void init() {
+        // Remember the scale we opened with so Cancel/Escape can revert a live preview.
+        originalScale = CommonConfig.getSpriteScaleFactor();
+        committed = false;
+
         // Seed the working anchor from where the overlay currently renders, so it doesn't jump.
         int[] anchor = TankSpriteOverlay.currentAnchor(this.width, this.height);
         anchorX = anchor[0];
@@ -48,9 +65,17 @@ public class OverlayEditScreen extends Screen {
 
         int cx = this.width / 2;
         int bottom = this.height - 28;
-
-        // Preset reset buttons (row above the action row).
         int presetY = bottom - 24;
+        int sliderY = presetY - 24;
+
+        // Scale slider (with a tooltip clarifying it stacks on top of Minecraft's GUI Scale).
+        ScaleSlider slider = new ScaleSlider(cx - 110, sliderY, 220, 20, originalScale);
+        slider.setTooltip(Tooltip.create(Component.literal(
+                "Adjusts the tank sprite size. The overlay already scales with Minecraft's "
+                        + "GUI Scale setting; this is an extra multiplier on top of that.")));
+        addRenderableWidget(slider);
+
+        // Preset reset buttons.
         int presetW = 78;
         int gap = 4;
         int rowWidth = presetW * 4 + gap * 3;
@@ -71,15 +96,17 @@ public class OverlayEditScreen extends Screen {
                 .bounds(cx + 4, bottom, 100, 20).build());
     }
 
-    /** Switches to a preset position and stores it immediately, then closes. */
+    /** Switches to a preset position and stores it (plus any scale change) immediately, then closes. */
     private void applyPreset(OverlayPosition position) {
-        CommonConfig.setOverlayPosition(position);
+        committed = true;
+        CommonConfig.setOverlayPosition(position); // saves, flushing the previewed scale too
         onClose();
     }
 
-    /** Persists the dragged position as a CUSTOM anchor and closes. */
+    /** Persists the dragged position as a CUSTOM anchor (plus any scale change) and closes. */
     private void save() {
-        CommonConfig.setCustomPosition(anchorX, anchorY);
+        committed = true;
+        CommonConfig.setCustomPosition(anchorX, anchorY); // saves, flushing the previewed scale too
         onClose();
     }
 
@@ -88,26 +115,26 @@ public class OverlayEditScreen extends Screen {
         // Light dim so the UI is readable but the world (and where the overlay sits on it) stays visible.
         renderBackground(graphics, mouseX, mouseY, partialTick);
 
+        // Title + instructions.
+        graphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 0xFFFFFFFF);
+        graphics.drawCenteredString(this.font, INSTRUCTION, this.width / 2, 22, 0xFFB0B0B0);
+
+        // Widgets (buttons + slider).
+        for (Renderable renderable : this.renderables) {
+            renderable.render(graphics, mouseX, mouseY, partialTick);
+        }
+
+        // Preview LAST so the whole composite (flat tank sprites + depth-tested item icons) draws
+        // consistently on top of the widgets. Buttons remain clickable (see mouseClicked).
         Player player = this.minecraft != null ? this.minecraft.player : null;
         if (player != null) {
             int w = TankSpriteOverlay.compositeWidthPx(player);
             int h = TankSpriteOverlay.compositeHeightPx();
 
-            // Highlight the draggable region.
             int border = dragging ? 0xFFFFE066 : 0x80FFFFFF;
             graphics.renderOutline(anchorX - 1, anchorY - 1, w + 2, h + 2, border);
 
-            // Live preview using the exact HUD rendering path (CUSTOM layout: items below, no padding).
             previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player, OverlayPosition.CUSTOM);
-        }
-
-        // Title + instructions.
-        graphics.drawCenteredString(this.font, this.title, this.width / 2, 8, 0xFFFFFFFF);
-        graphics.drawCenteredString(this.font, INSTRUCTION, this.width / 2, 22, 0xFFB0B0B0);
-
-        // Buttons on top of everything.
-        for (Renderable renderable : this.renderables) {
-            renderable.render(graphics, mouseX, mouseY, partialTick);
         }
     }
 
@@ -119,13 +146,17 @@ public class OverlayEditScreen extends Screen {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        // Let widgets (buttons/slider) win first, so a preview drawn over them stays clickable.
+        if (super.mouseClicked(mouseX, mouseY, button)) {
+            return true;
+        }
         if (button == 0 && this.minecraft != null && this.minecraft.player != null && isInsideOverlay(mouseX, mouseY)) {
             dragging = true;
             grabOffsetX = (int) Math.round(mouseX) - anchorX;
             grabOffsetY = (int) Math.round(mouseY) - anchorY;
             return true;
         }
-        return super.mouseClicked(mouseX, mouseY, button);
+        return false;
     }
 
     @Override
@@ -146,6 +177,15 @@ public class OverlayEditScreen extends Screen {
             return true;
         }
         return super.mouseReleased(mouseX, mouseY, button);
+    }
+
+    @Override
+    public void onClose() {
+        // If the editor wasn't committed (Cancel / Escape), undo any live scale preview.
+        if (!committed) {
+            CommonConfig.setSpriteScaleFactorTransient(originalScale);
+        }
+        super.onClose();
     }
 
     private boolean isInsideOverlay(double mouseX, double mouseY) {
@@ -169,5 +209,32 @@ public class OverlayEditScreen extends Screen {
     public boolean isPauseScreen() {
         // Keep the world rendering so the player can see the overlay in context.
         return false;
+    }
+
+    /** Slider mapping its 0..1 value onto the {@link #MIN_SCALE}..{@link #MAX_SCALE} scale range. */
+    private static final class ScaleSlider extends AbstractSliderButton {
+        ScaleSlider(int x, int y, int width, int height, double initialScale) {
+            super(x, y, width, height, Component.empty(), toSliderValue(initialScale));
+            updateMessage();
+        }
+
+        private static double toSliderValue(double scale) {
+            return Mth.clamp((scale - MIN_SCALE) / (MAX_SCALE - MIN_SCALE), 0.0, 1.0);
+        }
+
+        private double toScale() {
+            return MIN_SCALE + this.value * (MAX_SCALE - MIN_SCALE);
+        }
+
+        @Override
+        protected void updateMessage() {
+            setMessage(Component.literal(String.format("Tank Scale: %.2fx", toScale())));
+        }
+
+        @Override
+        protected void applyValue() {
+            // Live preview only; persisted when the editor commits.
+            CommonConfig.setSpriteScaleFactorTransient(toScale());
+        }
     }
 }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
@@ -27,14 +27,17 @@ import org.jetbrains.annotations.NotNull;
 public class OverlayEditScreen extends Screen {
 
     private static final Component INSTRUCTION =
-            Component.literal("Drag the overlay to position it, then Save. Or pick a preset.");
+            Component.literal("Drag the overlay or pick a preset to preview, then Save.");
 
     private static final double MIN_SCALE = 0.5;
     private static final double MAX_SCALE = 5.0;
 
     private final TankSpriteOverlay previewOverlay = new TankSpriteOverlay();
 
-    // Working anchor (top-left of the tank sprite) in GUI pixels.
+    // What Save will persist: a preset enum, or CUSTOM once the overlay has been dragged.
+    private OverlayPosition pendingPosition = OverlayPosition.TOP_LEFT;
+
+    // Working anchor (top-left of the composite) in GUI pixels.
     private int anchorX;
     private int anchorY;
 
@@ -56,11 +59,15 @@ public class OverlayEditScreen extends Screen {
         // Remember the scale we opened with so Cancel/Escape can revert a live preview.
         originalScale = CommonConfig.getSpriteScaleFactor();
         committed = false;
+        pendingPosition = CommonConfig.getOverlayPosition();
 
         // Seed the working anchor from where the overlay currently renders, so it doesn't jump.
-        int[] anchor = TankSpriteOverlay.currentAnchor(this.width, this.height);
-        anchorX = anchor[0];
-        anchorY = anchor[1];
+        Player player = this.minecraft != null ? this.minecraft.player : null;
+        if (player != null) {
+            int[] anchor = TankSpriteOverlay.currentAnchor(player, this.width, this.height);
+            anchorX = anchor[0];
+            anchorY = anchor[1];
+        }
         clampAnchor();
 
         int cx = this.width / 2;
@@ -96,17 +103,29 @@ public class OverlayEditScreen extends Screen {
                 .bounds(cx + 4, bottom, 100, 20).build());
     }
 
-    /** Switches to a preset position and stores it (plus any scale change) immediately, then closes. */
+    /**
+     * Previews a preset position without saving or closing, so the player can see it before
+     * committing. The preview moves to exactly where the live HUD would render that preset.
+     */
     private void applyPreset(OverlayPosition position) {
-        committed = true;
-        CommonConfig.setOverlayPosition(position); // saves, flushing the previewed scale too
-        onClose();
+        pendingPosition = position;
+        Player player = this.minecraft != null ? this.minecraft.player : null;
+        int w = player != null ? TankSpriteOverlay.compositeWidthPx(player) : 0;
+        int h = TankSpriteOverlay.compositeHeightPx();
+        int[] anchor = OverlayAnchor.resolveSprite(position, this.width, this.height, w, h);
+        anchorX = anchor[0];
+        anchorY = anchor[1];
+        clampAnchor();
     }
 
-    /** Persists the dragged position as a CUSTOM anchor (plus any scale change) and closes. */
+    /** Persists the previewed position (a preset, or CUSTOM if dragged) plus any scale change. */
     private void save() {
         committed = true;
-        CommonConfig.setCustomPosition(anchorX, anchorY); // saves, flushing the previewed scale too
+        if (pendingPosition == OverlayPosition.CUSTOM) {
+            CommonConfig.setCustomPosition(anchorX, anchorY); // saves, flushing the previewed scale too
+        } else {
+            CommonConfig.setOverlayPosition(pendingPosition); // saves, flushing the previewed scale too
+        }
         onClose();
     }
 
@@ -134,7 +153,7 @@ public class OverlayEditScreen extends Screen {
             int border = dragging ? 0xFFFFE066 : 0x80FFFFFF;
             graphics.renderOutline(anchorX - 1, anchorY - 1, w + 2, h + 2, border);
 
-            previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player, OverlayPosition.CUSTOM);
+            previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player);
         }
     }
 
@@ -152,6 +171,8 @@ public class OverlayEditScreen extends Screen {
         }
         if (button == 0 && this.minecraft != null && this.minecraft.player != null && isInsideOverlay(mouseX, mouseY)) {
             dragging = true;
+            // Dragging means the player is choosing a free position; Save will store it as CUSTOM.
+            pendingPosition = OverlayPosition.CUSTOM;
             grabOffsetX = (int) Math.round(mouseX) - anchorX;
             grabOffsetY = (int) Math.round(mouseY) - anchorY;
             return true;

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
@@ -14,15 +14,14 @@ import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * In-game editor for freely positioning and sizing the overlay.
+ * In-game editor for positioning and sizing the overlay.
  *
- * <p>The preview is drawn by the live {@link TankSpriteOverlay#renderCompositeAt} method at the same
- * anchor the HUD would use, so it is WYSIWYG — what you drop is exactly what renders. Dragging keeps
- * the cursor's offset within the sprite (a "grab offset"), so picking the sprite up anywhere doesn't
- * snap it under the cursor, and the saved anchor matches the previewed one precisely.
+ * <p>The preview is drawn by {@link TankSpriteOverlay#renderCompositeAt} at the anchor the HUD would
+ * use, so it matches the live overlay. Dragging preserves the cursor's offset within the sprite, so
+ * the sprite is not snapped under the cursor when picked up.
  *
- * <p>The scale slider previews live by writing the scale to the config in memory only; the value is
- * persisted when the editor commits (Save / a preset button) and reverted if the editor is cancelled.
+ * <p>The scale slider previews live in memory only; the value is persisted when the editor commits
+ * (Save or a preset) and reverted if cancelled.
  */
 public class OverlayEditScreen extends Screen {
 

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
@@ -18,14 +18,12 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Renders visual tank sprites showing fuel and water levels
- * This is the "simplified" view that shows tank graphics instead of text
+ * The "simplified" overlay: tank sprites showing fuel and water levels instead of text.
  *
- * <p>The overlay uses a single canonical layout for every position (chest tank on the left, tool
- * tank on the right, item icons directly below, no edge padding). Corner/preset positioning is
- * handled purely by the resolved anchor (see {@link OverlayAnchor}), using the full composite size
- * so nothing clips. Keeping one layout means the live HUD and the editor preview render identically,
- * which is what keeps drag-positioning WYSIWYG for presets as well as custom positions.
+ * <p>Layout is the same for every position — chest tank left, tool tank right, item icons below,
+ * no edge padding. Placement is decided entirely by the resolved anchor (see {@link OverlayAnchor}),
+ * which uses the full composite size so corners do not clip. A single layout lets the HUD and the
+ * editor preview share one render path.
  */
 public class TankSpriteOverlay implements LayeredDraw.Layer {
 
@@ -77,10 +75,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
 
     /**
      * Renders the tank composite with its top-left at GUI coordinates {@code (gx, gy)}.
-     *
-     * <p>Public so the overlay editor can draw an identical preview at an arbitrary anchor — this is
-     * what guarantees the editor is WYSIWYG: the HUD and the editor run the exact same rendering, in
-     * the exact same (single) layout.
+     * Public so the editor can preview at an arbitrary anchor using the same render path as the HUD.
      */
     public void renderCompositeAt(GuiGraphics graphics, int gx, int gy, Player player) {
         float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
@@ -102,16 +97,14 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         int scaledX = (int) (gx / scaleFactor);
         int scaledY = (int) (gy / scaleFactor);
 
-        // Decide layout based on which slots actually hold a tank, so we never render a phantom
-        // tank for an empty/non-tank slot.
+        // Only show a tank for a slot that actually holds one.
         boolean chestIsTank = TankDataManager.isWearingFuelCapableItem(player) || TankDataManager.isWearingWaterCapableItem(player);
         boolean toolIsTank = TankDataManager.isHoldingFuelCapableItem(player) || TankDataManager.isHoldingWaterCapableItem(player);
 
         if (chestIsTank && toolIsTank) {
             renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem);
         } else {
-            // Exactly one tank present (the render() gate guarantees at least one). Show whichever
-            // slot is the tank; the held item is only drawn when it is itself a tank.
+            // render() guarantees at least one tank; show whichever slot has it.
             ItemStack subject = chestIsTank ? tankItem : toolItem;
             renderSingleTankDisplay(graphics, scaledX, scaledY, subject);
         }
@@ -151,8 +144,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
 
         renderTankLayers(graphics, scaledX, scaledY, tankU, tankV, fuelU, 0, waterU, FRAME_HEIGHT);
 
-        // Item icon directly below. Only the tank item's icon is drawn — a non-tank held item must
-        // not appear (tank-capable held items use the dual layout instead).
+        // Item icon directly below the tank. A held non-tank item is intentionally not drawn here.
         int itemY = scaledY + FRAME_HEIGHT;
         GuiGameElement.of(tankItem).at(scaledX, itemY, 450).render(graphics);
     }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
@@ -20,6 +20,12 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Renders visual tank sprites showing fuel and water levels
  * This is the "simplified" view that shows tank graphics instead of text
+ *
+ * <p>The overlay uses a single canonical layout for every position (chest tank on the left, tool
+ * tank on the right, item icons directly below, no edge padding). Corner/preset positioning is
+ * handled purely by the resolved anchor (see {@link OverlayAnchor}), using the full composite size
+ * so nothing clips. Keeping one layout means the live HUD and the editor preview render identically,
+ * which is what keeps drag-positioning WYSIWYG for presets as well as custom positions.
  */
 public class TankSpriteOverlay implements LayeredDraw.Layer {
 
@@ -32,7 +38,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
     private static final int SPRITE_SHEET_HEIGHT = 96;
     private static final int MAX_LEVEL = 1600;
 
-    /** Item icon size (in unscaled sprite units) drawn beneath/above the tank. */
+    /** Item icon size (in unscaled sprite units) drawn beneath the tank. */
     private static final int ICON_SIZE = 16;
     /** Vertical extent of the whole composite (tank + item row) in unscaled sprite units. */
     private static final int COMPOSITE_UNITS_HIGH = FRAME_HEIGHT + ICON_SIZE; // 48
@@ -62,24 +68,21 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
             return; // No tank, nothing to show
         }
 
-        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
-        int renderWidth = (int) (FRAME_WIDTH * scaleFactor);
-        int renderHeight = (int) (FRAME_HEIGHT * scaleFactor);
-
         OverlayPosition position = CommonConfig.getOverlayPosition();
         int[] anchor = OverlayAnchor.resolveSprite(position, graphics.guiWidth(), graphics.guiHeight(),
-                renderWidth, renderHeight);
+                compositeWidthPx(player), compositeHeightPx());
 
-        renderCompositeAt(graphics, anchor[0], anchor[1], player, position);
+        renderCompositeAt(graphics, anchor[0], anchor[1], player);
     }
 
     /**
-     * Renders the tank composite with its top-left tank sprite at GUI coordinates {@code (gx, gy)}.
+     * Renders the tank composite with its top-left at GUI coordinates {@code (gx, gy)}.
      *
      * <p>Public so the overlay editor can draw an identical preview at an arbitrary anchor — this is
-     * what guarantees the editor is WYSIWYG: the HUD and the editor run the exact same rendering.
+     * what guarantees the editor is WYSIWYG: the HUD and the editor run the exact same rendering, in
+     * the exact same (single) layout.
      */
-    public void renderCompositeAt(GuiGraphics graphics, int gx, int gy, Player player, OverlayPosition position) {
+    public void renderCompositeAt(GuiGraphics graphics, int gx, int gy, Player player) {
         float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
         ItemStack tankItem = player.getItemBySlot(EquipmentSlot.CHEST);
         ItemStack toolItem = player.getItemInHand(InteractionHand.MAIN_HAND);
@@ -105,13 +108,12 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         boolean toolIsTank = TankDataManager.isHoldingFuelCapableItem(player) || TankDataManager.isHoldingWaterCapableItem(player);
 
         if (chestIsTank && toolIsTank) {
-            // Both a worn tank and a held tank: render two tank sprites with position-aware layout
-            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem, position);
+            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem);
         } else {
             // Exactly one tank present (the render() gate guarantees at least one). Show whichever
             // slot is the tank; the held item is only drawn when it is itself a tank.
             ItemStack subject = chestIsTank ? tankItem : toolItem;
-            renderSingleTankDisplay(graphics, scaledX, scaledY, subject, position);
+            renderSingleTankDisplay(graphics, scaledX, scaledY, subject);
         }
 
         graphics.pose().popPose();
@@ -121,8 +123,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
     }
 
     private void renderDualTankDisplay(GuiGraphics graphics, int scaledX, int scaledY,
-                                      ItemStack tankItem, ItemStack toolItem,
-                                      OverlayPosition position) {
+                                      ItemStack tankItem, ItemStack toolItem) {
         int tankU = 0;
         int tankV = 2 * FRAME_HEIGHT; // tank outline row
 
@@ -131,76 +132,29 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         int toolFuelU = frameU(TankDataManager.getFuelLevel(toolItem));
         int toolWaterU = frameU(TankDataManager.getWaterLevel(toolItem));
 
-        // Determine tank and item positioning based on overlay position
-        int tank1X, tank2X, item1X, item2X, itemY;
-        boolean toolTankOnLeft = position == OverlayPosition.TOP_RIGHT ||
-                                position == OverlayPosition.BOTTOM_RIGHT;
-        boolean itemsAbove = position == OverlayPosition.BOTTOM_LEFT ||
-                            position == OverlayPosition.BOTTOM_RIGHT;
-        boolean isRightSide = position == OverlayPosition.TOP_RIGHT ||
-                             position == OverlayPosition.BOTTOM_RIGHT;
+        int tank1X = scaledX;                 // Chest tank (left)
+        int tank2X = scaledX + FRAME_WIDTH;   // Tool tank (right)
+        int itemY = scaledY + FRAME_HEIGHT;   // Items directly below
 
-        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
-
-        // Apply right side padding to prevent clipping (preset right positions only)
-        int paddingOffset = isRightSide ? (int) (16 / scaleFactor) : 0;
-        int adjustedX = scaledX - paddingOffset;
-
-        if (toolTankOnLeft) {
-            // Tool tank left, chest tank right
-            tank1X = adjustedX + FRAME_WIDTH;  // Chest tank
-            tank2X = adjustedX;                // Tool tank
-            item1X = adjustedX + FRAME_WIDTH;  // Chest item
-            item2X = adjustedX;                // Tool item
-        } else {
-            // Chest tank left, tool tank right (default, incl. CUSTOM)
-            tank1X = adjustedX;                // Chest tank
-            tank2X = adjustedX + FRAME_WIDTH;  // Tool tank
-            item1X = adjustedX;                // Chest item
-            item2X = adjustedX + FRAME_WIDTH;  // Tool item
-        }
-
-        itemY = itemsAbove ? scaledY - ICON_SIZE : scaledY + FRAME_HEIGHT;
-
-        // Render chest tank sprite
         renderTankLayers(graphics, tank1X, scaledY, tankU, tankV, chestFuelU, 0, chestWaterU, FRAME_HEIGHT);
-
-        // Render tool tank sprite
         renderTankLayers(graphics, tank2X, scaledY, tankU, tankV, toolFuelU, 0, toolWaterU, FRAME_HEIGHT);
 
-        // Render items
-        GuiGameElement.of(tankItem).at(item1X, itemY, 450).render(graphics);
-        GuiGameElement.of(toolItem).at(item2X, itemY, 450).render(graphics);
+        GuiGameElement.of(tankItem).at(tank1X, itemY, 450).render(graphics);
+        GuiGameElement.of(toolItem).at(tank2X, itemY, 450).render(graphics);
     }
 
-    private void renderSingleTankDisplay(GuiGraphics graphics, int scaledX, int scaledY,
-                                       ItemStack tankItem,
-                                       OverlayPosition position) {
-        // Apply right side padding to prevent clipping (preset right positions only)
-        boolean isRightSide = position == OverlayPosition.TOP_RIGHT ||
-                             position == OverlayPosition.BOTTOM_RIGHT;
-        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
-        int paddingOffset = isRightSide ? (int) (16 / scaleFactor) : 0;
-        int adjustedX = scaledX - paddingOffset;
-
-        // Compute fuel/water frames from the tank we're actually showing (works for an empty tank too).
-        int fuelU = frameU(TankDataManager.getFuelLevel(tankItem));
-        int waterU = frameU(TankDataManager.getWaterLevel(tankItem));
+    private void renderSingleTankDisplay(GuiGraphics graphics, int scaledX, int scaledY, ItemStack tankItem) {
         int tankU = 0;
         int tankV = 2 * FRAME_HEIGHT; // tank outline row
+        int fuelU = frameU(TankDataManager.getFuelLevel(tankItem));
+        int waterU = frameU(TankDataManager.getWaterLevel(tankItem));
 
-        // Render single tank sprite
-        renderTankLayers(graphics, adjustedX, scaledY, tankU, tankV, fuelU, 0, waterU, FRAME_HEIGHT);
+        renderTankLayers(graphics, scaledX, scaledY, tankU, tankV, fuelU, 0, waterU, FRAME_HEIGHT);
 
-        // Determine item positioning based on overlay position
-        boolean itemsAbove = position == OverlayPosition.BOTTOM_LEFT ||
-                            position == OverlayPosition.BOTTOM_RIGHT;
-        int itemY = itemsAbove ? scaledY - ICON_SIZE : scaledY + FRAME_HEIGHT;
-
-        // Render only the tank item's icon. The held item is intentionally not drawn here — if the
-        // held item were a tank we'd be in renderDualTankDisplay, so anything else (e.g. bone meal)
-        // is irrelevant and must not appear next to the tank.
-        GuiGameElement.of(tankItem).at(adjustedX, itemY, 450).render(graphics);
+        // Item icon directly below. Only the tank item's icon is drawn — a non-tank held item must
+        // not appear (tank-capable held items use the dual layout instead).
+        int itemY = scaledY + FRAME_HEIGHT;
+        GuiGameElement.of(tankItem).at(scaledX, itemY, 450).render(graphics);
     }
 
     private void renderTankLayers(GuiGraphics graphics, int scaledX, int scaledY,
@@ -251,10 +205,8 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
      * The current top-left anchor for the configured position, in GUI pixels. Used by the editor to
      * seed the drag position so opening it shows the overlay exactly where it already renders.
      */
-    public static int[] currentAnchor(int guiW, int guiH) {
-        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
-        int renderWidth = (int) (FRAME_WIDTH * scaleFactor);
-        int renderHeight = (int) (FRAME_HEIGHT * scaleFactor);
-        return OverlayAnchor.resolveSprite(CommonConfig.getOverlayPosition(), guiW, guiH, renderWidth, renderHeight);
+    public static int[] currentAnchor(Player player, int guiW, int guiH) {
+        return OverlayAnchor.resolveSprite(CommonConfig.getOverlayPosition(), guiW, guiH,
+                compositeWidthPx(player), compositeHeightPx());
     }
 }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
@@ -1,9 +1,9 @@
 package com.jopgood.cfwinfo.client.gui;
 
 import com.jopgood.cfwinfo.common.config.CommonConfig;
+import com.jopgood.cfwinfo.common.config.CommonConfig.OverlayPosition;
 import com.jopgood.cfwinfo.common.data.TankDataManager;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.simibubi.create.AllItems;
 import net.createmod.catnip.gui.element.GuiGameElement;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
@@ -32,6 +32,11 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
     private static final int SPRITE_SHEET_HEIGHT = 96;
     private static final int MAX_LEVEL = 1600;
 
+    /** Item icon size (in unscaled sprite units) drawn beneath/above the tank. */
+    private static final int ICON_SIZE = 16;
+    /** Vertical extent of the whole composite (tank + item row) in unscaled sprite units. */
+    private static final int COMPOSITE_UNITS_HIGH = FRAME_HEIGHT + ICON_SIZE; // 48
+
 
     @Override
     public void render(@NotNull GuiGraphics graphics, @NotNull DeltaTracker deltaTracker) {
@@ -57,65 +62,27 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
             return; // No tank, nothing to show
         }
 
-        renderTankSprites(graphics, player);
-    }
-
-    private void renderTankSprites(GuiGraphics graphics, Player player) {
-        ItemStack tankItem = player.getItemBySlot(EquipmentSlot.CHEST);
-        ItemStack toolItem = player.getItemInHand(InteractionHand.MAIN_HAND);
-
-        // Get the fuel and water levels and calculate the frame index
-        int fuelLevel = (int) Math.round(TankDataManager.getFuelLevel(tankItem));
-        int waterLevel = (int) Math.round(TankDataManager.getWaterLevel(tankItem));
-
-        int fuelFrameIndex = ((MAX_LEVEL - fuelLevel) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
-        int waterFrameIndex = ((MAX_LEVEL - waterLevel) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
-
-        // Clamp frame indices to valid range
-        fuelFrameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, fuelFrameIndex));
-        waterFrameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, waterFrameIndex));
-
-        // Calculate texture coordinates (unchanged - these are UV coordinates in the sprite sheet)
-        int fuelU = (fuelFrameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
-        int fuelV = 0; // First row
-
-        int waterU = (waterFrameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
-        int waterV = FRAME_HEIGHT; // Second row
-
-        int tankU = 0;
-        int tankV = 2 * FRAME_HEIGHT; // Third row (tank outline)
-
-        // Get configurable scale factor and calculate dimensions
         float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
         int renderWidth = (int) (FRAME_WIDTH * scaleFactor);
         int renderHeight = (int) (FRAME_HEIGHT * scaleFactor);
 
-        // Position based on config - using scaled dimensions for positioning
-        int x, y;
-        CommonConfig.OverlayPosition position = CommonConfig.getOverlayPosition();
+        OverlayPosition position = CommonConfig.getOverlayPosition();
+        int[] anchor = OverlayAnchor.resolveSprite(position, graphics.guiWidth(), graphics.guiHeight(),
+                renderWidth, renderHeight);
 
-        y = switch (position) {
-            case TOP_LEFT -> {
-                x = 10;
-                yield 10;
-            }
-            case TOP_RIGHT -> {
-                x = graphics.guiWidth() - renderWidth - 10;
-                yield 10;
-            }
-            case BOTTOM_LEFT -> {
-                x = 10;
-                yield graphics.guiHeight() - renderHeight - 10;
-            }
-            case BOTTOM_RIGHT -> {
-                x = graphics.guiWidth() - renderWidth - 10;
-                yield graphics.guiHeight() - renderHeight - 10;
-            }
-            default -> {
-                x = graphics.guiWidth() / 2 - renderWidth / 2;
-                yield graphics.guiHeight() / 2 - renderHeight / 2;
-            }
-        };
+        renderCompositeAt(graphics, anchor[0], anchor[1], player, position);
+    }
+
+    /**
+     * Renders the tank composite with its top-left tank sprite at GUI coordinates {@code (gx, gy)}.
+     *
+     * <p>Public so the overlay editor can draw an identical preview at an arbitrary anchor — this is
+     * what guarantees the editor is WYSIWYG: the HUD and the editor run the exact same rendering.
+     */
+    public void renderCompositeAt(GuiGraphics graphics, int gx, int gy, Player player, OverlayPosition position) {
+        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
+        ItemStack tankItem = player.getItemBySlot(EquipmentSlot.CHEST);
+        ItemStack toolItem = player.getItemInHand(InteractionHand.MAIN_HAND);
 
         // Set up rendering
         RenderSystem.setShader(GameRenderer::getPositionTexShader);
@@ -125,13 +92,12 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         float opacity = CommonConfig.getOverlayOpacity() / 100.0f;
         RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, opacity);
 
-        // Use pose stack scaling for proper sprite scaling
+        // Use pose stack scaling for proper sprite scaling. We position in unscaled units
+        // (gx / scaleFactor) so that, after the scale, the sprite lands at gx in GUI pixels.
         graphics.pose().pushPose();
         graphics.pose().scale(scaleFactor, scaleFactor, 1.0f);
-        
-        // Adjust position to account for scaling
-        int scaledX = (int) (x / scaleFactor);
-        int scaledY = (int) (y / scaleFactor);
+        int scaledX = (int) (gx / scaleFactor);
+        int scaledY = (int) (gy / scaleFactor);
 
         // Decide layout based on which slots actually hold a tank, so we never render a phantom
         // tank for an empty/non-tank slot.
@@ -140,89 +106,81 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
 
         if (chestIsTank && toolIsTank) {
             // Both a worn tank and a held tank: render two tank sprites with position-aware layout
-            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem,
-                                tankU, tankV, fuelU, fuelV, waterU, waterV, position);
+            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem, position);
         } else {
             // Exactly one tank present (the render() gate guarantees at least one). Show whichever
             // slot is the tank; the held item is only drawn when it is itself a tank.
             ItemStack subject = chestIsTank ? tankItem : toolItem;
             renderSingleTankDisplay(graphics, scaledX, scaledY, subject, position);
         }
-        
+
         graphics.pose().popPose();
 
         // Reset shader color
         RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
     }
 
-    private void renderDualTankDisplay(GuiGraphics graphics, int scaledX, int scaledY, 
+    private void renderDualTankDisplay(GuiGraphics graphics, int scaledX, int scaledY,
                                       ItemStack tankItem, ItemStack toolItem,
-                                      int tankU, int tankV, int fuelU, int fuelV, int waterU, int waterV,
-                                      CommonConfig.OverlayPosition position) {
-        // Calculate tool tank levels
-        int toolFuelLevel = (int) Math.round(TankDataManager.getFuelLevel(toolItem));
-        int toolWaterLevel = (int) Math.round(TankDataManager.getWaterLevel(toolItem));
-        
-        int toolFuelFrameIndex = ((MAX_LEVEL - toolFuelLevel) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
-        int toolWaterFrameIndex = ((MAX_LEVEL - toolWaterLevel) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
-        
-        toolFuelFrameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, toolFuelFrameIndex));
-        toolWaterFrameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, toolWaterFrameIndex));
-        
-        int toolFuelU = (toolFuelFrameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
-        int toolWaterU = (toolWaterFrameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
-        
+                                      OverlayPosition position) {
+        int tankU = 0;
+        int tankV = 2 * FRAME_HEIGHT; // tank outline row
+
+        int chestFuelU = frameU(TankDataManager.getFuelLevel(tankItem));
+        int chestWaterU = frameU(TankDataManager.getWaterLevel(tankItem));
+        int toolFuelU = frameU(TankDataManager.getFuelLevel(toolItem));
+        int toolWaterU = frameU(TankDataManager.getWaterLevel(toolItem));
+
         // Determine tank and item positioning based on overlay position
         int tank1X, tank2X, item1X, item2X, itemY;
-        boolean toolTankOnLeft = position == CommonConfig.OverlayPosition.TOP_RIGHT || 
-                                position == CommonConfig.OverlayPosition.BOTTOM_RIGHT;
-        boolean itemsAbove = position == CommonConfig.OverlayPosition.BOTTOM_LEFT || 
-                            position == CommonConfig.OverlayPosition.BOTTOM_RIGHT;
-        boolean isRightSide = position == CommonConfig.OverlayPosition.TOP_RIGHT || 
-                             position == CommonConfig.OverlayPosition.BOTTOM_RIGHT;
+        boolean toolTankOnLeft = position == OverlayPosition.TOP_RIGHT ||
+                                position == OverlayPosition.BOTTOM_RIGHT;
+        boolean itemsAbove = position == OverlayPosition.BOTTOM_LEFT ||
+                            position == OverlayPosition.BOTTOM_RIGHT;
+        boolean isRightSide = position == OverlayPosition.TOP_RIGHT ||
+                             position == OverlayPosition.BOTTOM_RIGHT;
 
         float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
-        
-        // Apply right side padding to prevent clipping
-        int paddingOffset = isRightSide ? (int)(16 / scaleFactor) : 0;
+
+        // Apply right side padding to prevent clipping (preset right positions only)
+        int paddingOffset = isRightSide ? (int) (16 / scaleFactor) : 0;
         int adjustedX = scaledX - paddingOffset;
-        
+
         if (toolTankOnLeft) {
             // Tool tank left, chest tank right
             tank1X = adjustedX + FRAME_WIDTH;  // Chest tank
-            tank2X = adjustedX;                // Tool tank  
+            tank2X = adjustedX;                // Tool tank
             item1X = adjustedX + FRAME_WIDTH;  // Chest item
             item2X = adjustedX;                // Tool item
         } else {
-            // Chest tank left, tool tank right (default)
+            // Chest tank left, tool tank right (default, incl. CUSTOM)
             tank1X = adjustedX;                // Chest tank
             tank2X = adjustedX + FRAME_WIDTH;  // Tool tank
-            item1X = adjustedX;                // Chest item  
+            item1X = adjustedX;                // Chest item
             item2X = adjustedX + FRAME_WIDTH;  // Tool item
         }
-        
-        itemY = itemsAbove ? scaledY - 16 : scaledY + 32;
-        
+
+        itemY = itemsAbove ? scaledY - ICON_SIZE : scaledY + FRAME_HEIGHT;
+
         // Render chest tank sprite
-        renderTankLayers(graphics, tank1X, scaledY, tankU, tankV, fuelU, fuelV, waterU, waterV);
-        
-        // Render tool tank sprite  
-        renderTankLayers(graphics, tank2X, scaledY, tankU, tankV, 
-                        toolFuelU, fuelV, toolWaterU, waterV);
-        
+        renderTankLayers(graphics, tank1X, scaledY, tankU, tankV, chestFuelU, 0, chestWaterU, FRAME_HEIGHT);
+
+        // Render tool tank sprite
+        renderTankLayers(graphics, tank2X, scaledY, tankU, tankV, toolFuelU, 0, toolWaterU, FRAME_HEIGHT);
+
         // Render items
         GuiGameElement.of(tankItem).at(item1X, itemY, 450).render(graphics);
         GuiGameElement.of(toolItem).at(item2X, itemY, 450).render(graphics);
     }
-    
+
     private void renderSingleTankDisplay(GuiGraphics graphics, int scaledX, int scaledY,
                                        ItemStack tankItem,
-                                       CommonConfig.OverlayPosition position) {
-        // Apply right side padding to prevent clipping
-        boolean isRightSide = position == CommonConfig.OverlayPosition.TOP_RIGHT ||
-                             position == CommonConfig.OverlayPosition.BOTTOM_RIGHT;
+                                       OverlayPosition position) {
+        // Apply right side padding to prevent clipping (preset right positions only)
+        boolean isRightSide = position == OverlayPosition.TOP_RIGHT ||
+                             position == OverlayPosition.BOTTOM_RIGHT;
         float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
-        int paddingOffset = isRightSide ? (int)(16 / scaleFactor) : 0;
+        int paddingOffset = isRightSide ? (int) (16 / scaleFactor) : 0;
         int adjustedX = scaledX - paddingOffset;
 
         // Compute fuel/water frames from the tank we're actually showing (works for an empty tank too).
@@ -235,9 +193,9 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         renderTankLayers(graphics, adjustedX, scaledY, tankU, tankV, fuelU, 0, waterU, FRAME_HEIGHT);
 
         // Determine item positioning based on overlay position
-        boolean itemsAbove = position == CommonConfig.OverlayPosition.BOTTOM_LEFT ||
-                            position == CommonConfig.OverlayPosition.BOTTOM_RIGHT;
-        int itemY = itemsAbove ? scaledY - 16 : scaledY + 32;
+        boolean itemsAbove = position == OverlayPosition.BOTTOM_LEFT ||
+                            position == OverlayPosition.BOTTOM_RIGHT;
+        int itemY = itemsAbove ? scaledY - ICON_SIZE : scaledY + FRAME_HEIGHT;
 
         // Render only the tank item's icon. The held item is intentionally not drawn here — if the
         // held item were a tank we'd be in renderDualTankDisplay, so anything else (e.g. bone meal)
@@ -245,14 +203,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         GuiGameElement.of(tankItem).at(adjustedX, itemY, 450).render(graphics);
     }
 
-    /** Maps a fuel/water level to its column U offset in the sprite sheet. */
-    private static int frameU(double level) {
-        int frameIndex = ((MAX_LEVEL - (int) Math.round(level)) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
-        frameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, frameIndex));
-        return (frameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
-    }
-
-    private void renderTankLayers(GuiGraphics graphics, int scaledX, int scaledY, 
+    private void renderTankLayers(GuiGraphics graphics, int scaledX, int scaledY,
                                  int tankU, int tankV, int fuelU, int fuelV, int waterU, int waterV) {
         // Tank outline first (background layer)
         graphics.blit(SPRITE, scaledX, scaledY, tankU, tankV, FRAME_WIDTH, FRAME_HEIGHT,
@@ -265,5 +216,45 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         // Water level (top layer)
         graphics.blit(SPRITE, scaledX, scaledY, waterU, waterV, FRAME_WIDTH, FRAME_HEIGHT,
                 SPRITE_SHEET_WIDTH, SPRITE_SHEET_HEIGHT);
+    }
+
+    /** Maps a fuel/water level to its column U offset in the sprite sheet. */
+    private static int frameU(double level) {
+        int frameIndex = ((MAX_LEVEL - (int) Math.round(level)) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
+        frameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, frameIndex));
+        return (frameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
+    }
+
+    // ----- Helpers for the overlay editor (bounding box for hit-testing / clamping) -----
+
+    /** True when both a worn tank and a held tank are present (dual layout). */
+    public static boolean isDualLayout(Player player) {
+        boolean chestIsTank = TankDataManager.isWearingFuelCapableItem(player) || TankDataManager.isWearingWaterCapableItem(player);
+        boolean toolIsTank = TankDataManager.isHoldingFuelCapableItem(player) || TankDataManager.isHoldingWaterCapableItem(player);
+        return chestIsTank && toolIsTank;
+    }
+
+    /** Rendered width of the composite in GUI pixels, given the current scale and layout. */
+    public static int compositeWidthPx(Player player) {
+        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
+        int frames = isDualLayout(player) ? 2 : 1;
+        return (int) (frames * FRAME_WIDTH * scaleFactor);
+    }
+
+    /** Rendered height of the composite (tank + item row) in GUI pixels. */
+    public static int compositeHeightPx() {
+        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
+        return (int) (COMPOSITE_UNITS_HIGH * scaleFactor);
+    }
+
+    /**
+     * The current top-left anchor for the configured position, in GUI pixels. Used by the editor to
+     * seed the drag position so opening it shows the overlay exactly where it already renders.
+     */
+    public static int[] currentAnchor(int guiW, int guiH) {
+        float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
+        int renderWidth = (int) (FRAME_WIDTH * scaleFactor);
+        int renderHeight = (int) (FRAME_HEIGHT * scaleFactor);
+        return OverlayAnchor.resolveSprite(CommonConfig.getOverlayPosition(), guiW, guiH, renderWidth, renderHeight);
     }
 }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
@@ -73,11 +73,24 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         renderCompositeAt(graphics, anchor[0], anchor[1], player);
     }
 
+    /** Depth at which item icons are drawn on the HUD, so they sit above other HUD elements. */
+    private static final int HUD_ITEM_Z = 450;
+
+    /**
+     * Renders the tank composite with its top-left at GUI coordinates {@code (gx, gy)} for the HUD.
+     */
+    public void renderCompositeAt(GuiGraphics graphics, int gx, int gy, Player player) {
+        renderCompositeAt(graphics, gx, gy, player, HUD_ITEM_Z);
+    }
+
     /**
      * Renders the tank composite with its top-left at GUI coordinates {@code (gx, gy)}.
      * Public so the editor can preview at an arbitrary anchor using the same render path as the HUD.
+     *
+     * @param itemZ depth for the item icons; the editor passes a low value so the whole preview
+     *              stays behind the editor controls (the HUD uses {@link #HUD_ITEM_Z}).
      */
-    public void renderCompositeAt(GuiGraphics graphics, int gx, int gy, Player player) {
+    public void renderCompositeAt(GuiGraphics graphics, int gx, int gy, Player player, int itemZ) {
         float scaleFactor = (float) CommonConfig.getSpriteScaleFactor();
         ItemStack tankItem = player.getItemBySlot(EquipmentSlot.CHEST);
         ItemStack toolItem = player.getItemInHand(InteractionHand.MAIN_HAND);
@@ -102,11 +115,11 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         boolean toolIsTank = TankDataManager.isHoldingFuelCapableItem(player) || TankDataManager.isHoldingWaterCapableItem(player);
 
         if (chestIsTank && toolIsTank) {
-            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem);
+            renderDualTankDisplay(graphics, scaledX, scaledY, tankItem, toolItem, itemZ);
         } else {
             // render() guarantees at least one tank; show whichever slot has it.
             ItemStack subject = chestIsTank ? tankItem : toolItem;
-            renderSingleTankDisplay(graphics, scaledX, scaledY, subject);
+            renderSingleTankDisplay(graphics, scaledX, scaledY, subject, itemZ);
         }
 
         graphics.pose().popPose();
@@ -116,7 +129,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
     }
 
     private void renderDualTankDisplay(GuiGraphics graphics, int scaledX, int scaledY,
-                                      ItemStack tankItem, ItemStack toolItem) {
+                                      ItemStack tankItem, ItemStack toolItem, int itemZ) {
         int tankU = 0;
         int tankV = 2 * FRAME_HEIGHT; // tank outline row
 
@@ -132,11 +145,11 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         renderTankLayers(graphics, tank1X, scaledY, tankU, tankV, chestFuelU, 0, chestWaterU, FRAME_HEIGHT);
         renderTankLayers(graphics, tank2X, scaledY, tankU, tankV, toolFuelU, 0, toolWaterU, FRAME_HEIGHT);
 
-        GuiGameElement.of(tankItem).at(tank1X, itemY, 450).render(graphics);
-        GuiGameElement.of(toolItem).at(tank2X, itemY, 450).render(graphics);
+        GuiGameElement.of(tankItem).at(tank1X, itemY, itemZ).render(graphics);
+        GuiGameElement.of(toolItem).at(tank2X, itemY, itemZ).render(graphics);
     }
 
-    private void renderSingleTankDisplay(GuiGraphics graphics, int scaledX, int scaledY, ItemStack tankItem) {
+    private void renderSingleTankDisplay(GuiGraphics graphics, int scaledX, int scaledY, ItemStack tankItem, int itemZ) {
         int tankU = 0;
         int tankV = 2 * FRAME_HEIGHT; // tank outline row
         int fuelU = frameU(TankDataManager.getFuelLevel(tankItem));
@@ -146,7 +159,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
 
         // Item icon directly below the tank. A held non-tank item is intentionally not drawn here.
         int itemY = scaledY + FRAME_HEIGHT;
-        GuiGameElement.of(tankItem).at(scaledX, itemY, 450).render(graphics);
+        GuiGameElement.of(tankItem).at(scaledX, itemY, itemZ).render(graphics);
     }
 
     private void renderTankLayers(GuiGraphics graphics, int scaledX, int scaledY,

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankTooltipOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankTooltipOverlay.java
@@ -129,6 +129,11 @@ public class TankTooltipOverlay implements LayeredDraw.Layer {
                 posX = width - tooltipTextWidth - padding;
                 posY = height - tooltipHeight - padding;
                 break;
+            case CUSTOM:
+                // Free position dragged by the player; clamp so the tooltip stays on screen.
+                posX = OverlayAnchor.clamp(CommonConfig.getCustomX(), 0, Math.max(0, width - tooltipTextWidth));
+                posY = OverlayAnchor.clamp(CommonConfig.getCustomY(), 0, Math.max(0, height - tooltipHeight));
+                break;
             case TOP_LEFT:
             default:
                 posX = padding;

--- a/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
+++ b/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
@@ -166,6 +166,17 @@ public class CommonConfig {
         return safeGet(INSTANCE.spriteScaleFactor, DEFAULT_SPRITE_SCALE_FACTOR);
     }
 
+    /**
+     * Updates the sprite scale in memory only (no disk write). Used for live previewing in the
+     * overlay editor; the value is persisted later when the editor commits via
+     * {@link #setCustomPosition} or {@link #setOverlayPosition}, or reverted on cancel.
+     */
+    public static void setSpriteScaleFactorTransient(double value) {
+        if (SPEC.isLoaded()) {
+            INSTANCE.spriteScaleFactor.set(value);
+        }
+    }
+
     public static int getCustomX() {
         return safeGet(INSTANCE.customX, DEFAULT_CUSTOM_X);
     }

--- a/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
+++ b/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
@@ -99,11 +99,8 @@ public class CommonConfig {
     private static final int DEFAULT_CUSTOM_Y = 10;
 
     /**
-     * Reads a config value, falling back to {@code fallback} if the config spec has
-     * not yet been loaded into memory. NeoForge throws
-     * "trying to get config values before these are loaded to memory" if a value is
-     * accessed too early (e.g. during early client ticks or before the config file is
-     * bound), so every accessor routes through here to stay crash-safe.
+     * Reads a config value, falling back to {@code fallback} until the spec is loaded.
+     * NeoForge throws if a value is accessed before the config is bound to memory.
      */
     private static <T> T safeGet(ModConfigSpec.ConfigValue<T> value, T fallback) {
         if (SPEC.isLoaded()) {
@@ -113,14 +110,9 @@ public class CommonConfig {
     }
 
     /**
-     * Writes a config value, but only once the config spec has been loaded. Setting
-     * a value before load would throw the same "not loaded" error, so the write is
-     * silently skipped until the config is available.
-     *
-     * <p>{@link ModConfigSpec.ConfigValue#set} only updates the in-memory config; it does
-     * not flush to disk, so runtime changes (e.g. toggling simplified mode with a keybind)
-     * would be lost on restart. We call {@link ModConfigSpec#save()} afterwards to persist
-     * the change to the config file.
+     * Writes a config value once the spec is loaded, then flushes it to disk.
+     * {@link ModConfigSpec.ConfigValue#set} only updates the in-memory config, so an explicit
+     * {@link ModConfigSpec#save()} is needed for runtime changes to survive a restart.
      */
     private static <T> void safeSet(ModConfigSpec.ConfigValue<T> value, T newValue) {
         if (SPEC.isLoaded()) {

--- a/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
+++ b/src/main/java/com/jopgood/cfwinfo/common/config/CommonConfig.java
@@ -25,6 +25,11 @@ public class CommonConfig {
     public final ModConfigSpec.EnumValue<OverlayPosition> overlayPosition;
     public final ModConfigSpec.DoubleValue spriteScaleFactor;
 
+    // Custom (dragged) overlay position, in GUI-scaled pixels. Only used when
+    // overlayPosition == CUSTOM. Stored as the top-left anchor of the overlay.
+    public final ModConfigSpec.IntValue customX;
+    public final ModConfigSpec.IntValue customY;
+
     private CommonConfig(ModConfigSpec.Builder builder) {
         // Create a section for overlay settings
         builder.push("overlay");
@@ -59,6 +64,16 @@ public class CommonConfig {
                 .translation("cfwinfo.config.messages_enabled")
                 .define("messages_enabled", false);
 
+        customX = builder
+                .comment("Custom overlay X position in GUI pixels (used only when overlay_position = CUSTOM)")
+                .translation("cfwinfo.config.custom_x")
+                .defineInRange("custom_x", 10, 0, 10000);
+
+        customY = builder
+                .comment("Custom overlay Y position in GUI pixels (used only when overlay_position = CUSTOM)")
+                .translation("cfwinfo.config.custom_y")
+                .defineInRange("custom_y", 10, 0, 10000);
+
         builder.pop(); // Exit overlay section
     }
 
@@ -67,7 +82,9 @@ public class CommonConfig {
         TOP_LEFT,
         TOP_RIGHT,
         BOTTOM_LEFT,
-        BOTTOM_RIGHT
+        BOTTOM_RIGHT,
+        /** Free position dragged by the player; uses customX / customY. */
+        CUSTOM
     }
 
     // Default values, used as a fallback whenever a config value is requested
@@ -78,6 +95,8 @@ public class CommonConfig {
     private static final int DEFAULT_OVERLAY_OPACITY = 80;
     private static final OverlayPosition DEFAULT_OVERLAY_POSITION = OverlayPosition.TOP_LEFT;
     private static final double DEFAULT_SPRITE_SCALE_FACTOR = 2.0;
+    private static final int DEFAULT_CUSTOM_X = 10;
+    private static final int DEFAULT_CUSTOM_Y = 10;
 
     /**
      * Reads a config value, falling back to {@code fallback} if the config spec has
@@ -139,8 +158,33 @@ public class CommonConfig {
         return safeGet(INSTANCE.overlayPosition, DEFAULT_OVERLAY_POSITION);
     }
 
+    public static void setOverlayPosition(OverlayPosition position) {
+        safeSet(INSTANCE.overlayPosition, position);
+    }
+
     public static double getSpriteScaleFactor() {
         return safeGet(INSTANCE.spriteScaleFactor, DEFAULT_SPRITE_SCALE_FACTOR);
+    }
+
+    public static int getCustomX() {
+        return safeGet(INSTANCE.customX, DEFAULT_CUSTOM_X);
+    }
+
+    public static int getCustomY() {
+        return safeGet(INSTANCE.customY, DEFAULT_CUSTOM_Y);
+    }
+
+    /**
+     * Persists a freely-dragged overlay position and switches the overlay into CUSTOM mode.
+     * Writes all three values then saves once, to avoid three separate disk writes.
+     */
+    public static void setCustomPosition(int x, int y) {
+        if (SPEC.isLoaded()) {
+            INSTANCE.customX.set(x);
+            INSTANCE.customY.set(y);
+            INSTANCE.overlayPosition.set(OverlayPosition.CUSTOM);
+            SPEC.save();
+        }
     }
 
 }

--- a/src/main/java/com/jopgood/cfwinfo/common/data/TankDataManager.java
+++ b/src/main/java/com/jopgood/cfwinfo/common/data/TankDataManager.java
@@ -15,11 +15,9 @@ public class TankDataManager {
     private static final String CSA_NAMESPACE = "create_sa";
 
     /**
-     * Create: Stuff 'N Additions items that can hold fuel. Detection by item identity lets us
-     * recognise a tank even when it is empty — CS&A only writes the "tagFuel"/"tagWater" NBT keys
-     * when there is content, so a freshly crafted or fully drained tank would otherwise look like a
-     * non-tank item. Derived from which item/procedure classes reference "tagFuel" in CS&A.
-     * Update this set if CS&A adds or renames fuel-holding items.
+     * Create: Stuff 'N Additions item ids that can hold fuel. Identity detection recognises a tank
+     * even when empty, since CS&A only writes the "tagFuel"/"tagWater" NBT once a tank has content.
+     * Update if CS&A adds or renames fuel-holding items.
      */
     private static final Set<String> FUEL_CAPABLE_ITEMS = Set.of(
             "andesite_jetpack_chestplate",
@@ -37,8 +35,7 @@ public class TankDataManager {
     );
 
     /**
-     * Create: Stuff 'N Additions items that can hold water. See {@link #FUEL_CAPABLE_ITEMS} for why
-     * identity detection is used. Derived from which item/procedure classes reference "tagWater".
+     * Create: Stuff 'N Additions item ids that can hold water. See {@link #FUEL_CAPABLE_ITEMS}.
      */
     private static final Set<String> WATER_CAPABLE_ITEMS = Set.of(
             "brass_jetpack_chestplate",

--- a/src/main/resources/assets/cfwinfo/lang/en_gb.json
+++ b/src/main/resources/assets/cfwinfo/lang/en_gb.json
@@ -6,8 +6,11 @@
   "cfwinfo.config.overlay_opacity": "Overlay Opacity",
   "cfwinfo.config.sprite_scale_factor": "Tank Scale Factor",
   "cfwinfo.config.messages_enabled": "Show debug messages",
+  "cfwinfo.config.custom_x": "Custom Overlay X",
+  "cfwinfo.config.custom_y": "Custom Overlay Y",
 
   "key.categories.cfwinfo": "Create: Fuel and Water Information",
   "key.cfwinfo.toggle_overlay": "Toggle Overlay",
-  "key.cfwinfo.toggle_simplified": "Toggle Simplified"
+  "key.cfwinfo.toggle_simplified": "Toggle Simplified",
+  "key.cfwinfo.edit_overlay": "Edit Overlay Position"
 }

--- a/src/main/resources/assets/cfwinfo/lang/en_us.json
+++ b/src/main/resources/assets/cfwinfo/lang/en_us.json
@@ -6,8 +6,11 @@
   "cfwinfo.config.overlay_opacity": "Overlay Opacity",
   "cfwinfo.config.sprite_scale_factor": "Tank Scale Factor",
   "cfwinfo.config.messages_enabled": "Show debug messages",
+  "cfwinfo.config.custom_x": "Custom Overlay X",
+  "cfwinfo.config.custom_y": "Custom Overlay Y",
 
   "key.categories.cfwinfo": "Create: Fuel and Water Information",
   "key.cfwinfo.toggle_overlay": "Toggle Overlay",
-  "key.cfwinfo.toggle_simplified": "Toggle Simplified"
+  "key.cfwinfo.toggle_simplified": "Toggle Simplified",
+  "key.cfwinfo.edit_overlay": "Edit Overlay Position"
 }


### PR DESCRIPTION
Adds an in-game editor for positioning and sizing the overlay. Targets **v1.8.0**.

## Features

- **Drag-to-position editor** — a new keybind (default `O`) opens an in-game editor where the overlay can be dragged anywhere. The preview uses the live HUD render path, so it is WYSIWYG. Controls hide while dragging for an unobstructed view.
- **Preset positions** — Top Left / Top Right / Bottom Left / Bottom Right preview a corner before committing (no longer auto-apply/close).
- **Tank scale slider** — 0.5x–5.0x, live preview, with a tooltip noting it stacks on top of Minecraft's GUI Scale. Position + scale are saved together on Save and reverted on Cancel.

## How it works

- `OverlayAnchor` resolves every position (presets + custom) in one coordinate space (GUI-scaled pixels). The HUD and the editor share the anchor *and* the render path, so a position chosen in the editor matches the HUD exactly.
- The overlay uses a single layout for all positions (chest left, tool right, items below); corner anchors use the full composite size so nothing clips.
- Custom positions persist via `customX`/`customY` + a `CUSTOM` `OverlayPosition`; runtime changes are flushed to disk (building on the persistence fix from 1.7.0).

## Notes / follow-ups
- The editor preview always shows the simplified sprite composite; a tooltip-accurate preview for detailed mode could be a later enhancement.

## Testing
- `./gradlew build` passes.
- Manually verified in-game: drag positioning (offset-free), presets preview + match the HUD, scale slider live preview + commit/revert, persistence across restarts, and controls hidden while dragging.