### PR TITLE
ci: automate releases to GitHub, CurseForge and Modrinth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 
 on: [push, pull_request]
 
@@ -23,3 +23,39 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build
+
+  # Gate that every version bump ships with release notes. Runs on PRs into main
+  # (and pushes to main) so you can never tag a version whose CHANGELOG / docs entry
+  # is missing. Between releases the version stays at the last released number, which
+  # already has notes, so this passes until you intentionally bump mod_version.
+  release-readiness:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify release notes exist for current mod_version
+        run: |
+          VERSION=$(grep -E '^mod_version=' gradle.properties | cut -d= -f2 | tr -d '[:space:]')
+          echo "mod_version = $VERSION"
+
+          NOTES="docs/releases/v${VERSION}.md"
+          FAIL=0
+
+          if [ ! -f "$NOTES" ]; then
+            echo "::error file=gradle.properties::Missing release notes file '$NOTES' for version $VERSION."
+            FAIL=1
+          fi
+
+          if ! grep -q "\[${VERSION}\]" CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::No '[$VERSION]' section found in CHANGELOG.md."
+            FAIL=1
+          fi
+
+          if [ "$FAIL" -ne 0 ]; then
+            echo "Add the release notes before merging a version bump. See RELEASING.md."
+            exit 1
+          fi
+
+          echo "Release notes present for $VERSION."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+# Fires on the manual tag push that ends your release flow:
+#   git tag vX.Y.Z && git push --tags
+# Everything below (build, GitHub Release, CurseForge + Modrinth upload) is automated.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write  # needed for mc-publish to create the GitHub Release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Guard against a tag that doesn't match the version in gradle.properties.
+      - name: Resolve and verify version
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          MOD_VERSION=$(grep -E '^mod_version=' gradle.properties | cut -d= -f2 | tr -d '[:space:]')
+
+          if [ "$VERSION" != "$MOD_VERSION" ]; then
+            echo "::error::Tag '$TAG' (version $VERSION) does not match mod_version=$MOD_VERSION in gradle.properties."
+            exit 1
+          fi
+
+          NOTES="docs/releases/v${VERSION}.md"
+          if [ ! -f "$NOTES" ]; then
+            echo "::error::Missing release notes '$NOTES'."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "notes=$NOTES" >> "$GITHUB_OUTPUT"
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Publish to GitHub, CurseForge and Modrinth
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          # ---- GitHub Release (always runs; token is provided automatically) ----
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: "v${{ steps.version.outputs.version }}"
+          version: ${{ steps.version.outputs.version }}
+          version-type: release
+          changelog-file: ${{ steps.version.outputs.notes }}
+
+          files: build/libs/cfwinfo-${{ steps.version.outputs.version }}.jar
+
+          # ---- CurseForge (project 1023209) ----
+          curseforge-id: 1023209
+          curseforge-token: ${{ secrets.CF_API_TOKEN }}
+
+          # ---- Modrinth (auto-skips until MODRINTH_TOKEN + project id are set) ----
+          modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
+          # ---- Shared metadata ----
+          loaders: neoforge
+          game-versions: '1.21.1'
+          java: '21'
+          dependencies: |
+            create(required)
+            create-stuff-additions(optional)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,5 +145,11 @@ the IntelliJ run-config dialog — the generated config can be overwritten on Gr
 - On a fresh clone: `chmod +x gradlew`.
 - Create dependency uses `transitive = false` (we declare Ponder/Flywheel/Registrate explicitly) — don't "fix" that. Create published a `:slim` classifier through 6.0.10 but **dropped it at 6.0.11**, so from 6.0.11+ we depend on the full jar (no `:slim`).
 - Build output jar: `build/libs/cfwinfo-<version>.jar`. Bump `mod_version` before building.
-- There is a GitHub Actions workflow under `.github/workflows` and release notes in
-  `docs/releases`.
+- CI/CD lives under `.github/workflows`: `build.yml` (build on every push/PR + a
+  `release-readiness` gate that fails a PR if `mod_version` lacks a matching
+  `CHANGELOG.md` entry and `docs/releases/vX.md`), and `release.yml` (triggered by a
+  `v*` tag push — builds, then `Kir-Antipov/mc-publish` cuts the GitHub Release and
+  uploads to CurseForge + Modrinth). Full process and one-time secret setup
+  (`CF_API_TOKEN`, `MODRINTH_TOKEN`, `MODRINTH_PROJECT_ID` var) are in `RELEASING.md`.
+  Release notes are hand-authored in `docs/releases` (the chosen approach over
+  commit-driven generators like release-please).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing `cfwinfo`
+
+This repo automates everything mechanical about a release. You stay in charge of
+the *narrative* (changelog + release notes); CI handles building, the GitHub
+Release, and uploading to CurseForge and Modrinth.
+
+## The flow
+
+1. **Branch off `main`** and do the work as usual.
+2. In the **release PR**, before merging:
+   - Bump `mod_version` in [`gradle.properties`](gradle.properties).
+   - Add a `## [X.Y.Z] - YYYY-MM-DD` section to [`CHANGELOG.md`](CHANGELOG.md).
+   - Add the user-facing notes file `docs/releases/vX.Y.Z.md` (this becomes the
+     GitHub Release / CurseForge / Modrinth changelog body verbatim, so write it
+     for players).
+   - The **`release-readiness`** CI job fails the PR if either of those is missing
+     for the new `mod_version`.
+3. **Merge to `main`** once CI is green.
+4. Locally: `git checkout main && git pull`.
+5. **Tag and push** — this is the only manual release step:
+   ```bash
+   git tag v1.9.0
+   git push --tags
+   ```
+6. The **Release** workflow takes over: it verifies the tag matches `mod_version`,
+   builds the jar, creates the GitHub Release (body = `docs/releases/v1.9.0.md`,
+   jar attached), and publishes to CurseForge + Modrinth. No manual CurseForge
+   upload needed.
+
+> The tag must match `mod_version` (e.g. tag `v1.9.0` ⇄ `mod_version=1.9.0`),
+> or the workflow fails fast.
+
+## One-time setup
+
+Add these under **Settings → Secrets and variables → Actions**:
+
+| Kind | Name | Value |
+|---|---|---|
+| Secret | `CF_API_TOKEN` | CurseForge API token from <https://legacy.curseforge.com/account/api-tokens> |
+| Secret | `MODRINTH_TOKEN` | Modrinth PAT (scope: *Create versions*) from <https://modrinth.com/settings/pats> — only once you have a Modrinth project |
+| Variable | `MODRINTH_PROJECT_ID` | Your Modrinth project id/slug |
+
+`GITHUB_TOKEN` is provided automatically — no setup.
+
+Until `MODRINTH_TOKEN` / `MODRINTH_PROJECT_ID` are set, the Modrinth step is
+**skipped automatically** (mc-publish skips any platform with missing
+credentials); CurseForge and the GitHub Release still run.
+
+The CurseForge project id (`1023209`), supported loader (`neoforge`), game
+version (`1.21.1`), and dependency relations are set in
+[`.github/workflows/release.yml`](.github/workflows/release.yml). Update them
+there when the platform target changes (e.g. a Create/Minecraft version bump).


### PR DESCRIPTION
Automates the mechanical parts of releasing while keeping changelog/release-note authoring manual.

## What changed
- **`build.yml` → CI**: keeps the build job, adds a **`release-readiness`** gate (PRs to main / pushes to main) that fails if `mod_version` has no matching `CHANGELOG.md` section **and** `docs/releases/vX.md`.
- **`release.yml` (new)**: on a `v*` tag push, builds and publishes via `Kir-Antipov/mc-publish` to the GitHub Release (body = `docs/releases/<tag>.md`, jar attached), CurseForge (1023209), and Modrinth. Modrinth auto-skips until its token/project id are set.
- **`RELEASING.md` (new)**: documents the flow + one-time secret setup.
- **`CLAUDE.md`**: updated CI/CD notes.

## New release flow
Branch → PR (CI gates that notes exist) → merge → `git checkout main && git pull` → `git tag vX.Y.Z && git push --tags`. Everything after the tag push is automated; the manual CurseForge upload is gone.

## Notes
- Secrets/vars (`CF_API_TOKEN`, `MODRINTH_TOKEN`, `MODRINTH_PROJECT_ID`) are configured.
- Publish metadata marks `create(required)` / `create-stuff-additions(optional)`; this is listing metadata only and does not change `neoforge.mods.toml`.