### PR TITLE
chore: set license to MIT and refresh CLAUDE.md version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ staying current on 1.21.1 or backporting to 1.20.1 (see Roadmap). Do not attempt
 | Build plugin | ModDevGradle `net.neoforged.moddev` `2.0.107` |
 | Gradle | `8.14.3` (wrapper) |
 | Mappings | Parchment `1.21.1` / `2024.11.17` |
-| Mod id / version | `cfwinfo` / `1.6.0` |
+| Mod id / version | `cfwinfo` / `1.8.0` |
 | Group | `com.jopgood.cfwinfo` |
 | License | MIT (per `LICENSE.txt`) — note `gradle.properties` `mod_license` still has the template default "All Rights Reserved"; reconcile. |
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ mod_id=cfwinfo
 # The human-readable display name for the mod.
 mod_name=Create: Fuel & Water Information
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
-mod_license=All Rights Reserved
+mod_license=MIT
 # The mod version. See https://semver.org/
 mod_version=1.8.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.


### PR DESCRIPTION
Two small housekeeping fixes ahead of the first automated release.

- **License**: `mod_license` was `All Rights Reserved` but the repo is MIT (`LICENSE.txt`). Changed to `MIT`. This value flows through `${mod_license}` into the jar's `neoforge.mods.toml` and the published CurseForge/Modrinth metadata, so without this the next release would ship a license contradicting the actual one. (Confirmed the Modrinth project already declares MIT.)
- **CLAUDE.md**: bumped the stale `1.6.0` in the stack table to `1.8.0`.

No version bump, so the `release-readiness` gate stays satisfied (1.8.0 already has its CHANGELOG entry and docs notes).