### PR TITLE
fix: read standalone tank levels from tagStock

### DIFF
--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
@@ -34,7 +34,6 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
     private static final int TOTAL_FRAMES = 18;
     private static final int SPRITE_SHEET_WIDTH = 270;
     private static final int SPRITE_SHEET_HEIGHT = 96;
-    private static final int MAX_LEVEL = 1600;
 
     /** Item icon size (in unscaled sprite units) drawn beneath the tank. */
     private static final int ICON_SIZE = 16;
@@ -133,10 +132,10 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         int tankU = 0;
         int tankV = 2 * FRAME_HEIGHT; // tank outline row
 
-        int chestFuelU = frameU(TankDataManager.getFuelLevel(tankItem));
-        int chestWaterU = frameU(TankDataManager.getWaterLevel(tankItem));
-        int toolFuelU = frameU(TankDataManager.getFuelLevel(toolItem));
-        int toolWaterU = frameU(TankDataManager.getWaterLevel(toolItem));
+        int chestFuelU = frameU(TankDataManager.getFuelFraction(tankItem));
+        int chestWaterU = frameU(TankDataManager.getWaterFraction(tankItem));
+        int toolFuelU = frameU(TankDataManager.getFuelFraction(toolItem));
+        int toolWaterU = frameU(TankDataManager.getWaterFraction(toolItem));
 
         int tank1X = scaledX;                 // Chest tank (left)
         int tank2X = scaledX + FRAME_WIDTH;   // Tool tank (right)
@@ -152,8 +151,8 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
     private void renderSingleTankDisplay(GuiGraphics graphics, int scaledX, int scaledY, ItemStack tankItem, int itemZ) {
         int tankU = 0;
         int tankV = 2 * FRAME_HEIGHT; // tank outline row
-        int fuelU = frameU(TankDataManager.getFuelLevel(tankItem));
-        int waterU = frameU(TankDataManager.getWaterLevel(tankItem));
+        int fuelU = frameU(TankDataManager.getFuelFraction(tankItem));
+        int waterU = frameU(TankDataManager.getWaterFraction(tankItem));
 
         renderTankLayers(graphics, scaledX, scaledY, tankU, tankV, fuelU, 0, waterU, FRAME_HEIGHT);
 
@@ -177,9 +176,10 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
                 SPRITE_SHEET_WIDTH, SPRITE_SHEET_HEIGHT);
     }
 
-    /** Maps a fuel/water level to its column U offset in the sprite sheet. */
-    private static int frameU(double level) {
-        int frameIndex = ((MAX_LEVEL - (int) Math.round(level)) * (TOTAL_FRAMES - 1)) / MAX_LEVEL;
+    /** Maps a fill fraction (0..1) to its column U offset in the sprite sheet (frame 0 = full). */
+    private static int frameU(double fraction) {
+        fraction = Math.max(0.0, Math.min(1.0, fraction));
+        int frameIndex = (int) Math.round((1.0 - fraction) * (TOTAL_FRAMES - 1));
         frameIndex = Math.max(0, Math.min(TOTAL_FRAMES - 1, frameIndex));
         return (frameIndex % FRAMES_PER_ROW) * FRAME_WIDTH;
     }

--- a/src/main/java/com/jopgood/cfwinfo/common/data/TankDataManager.java
+++ b/src/main/java/com/jopgood/cfwinfo/common/data/TankDataManager.java
@@ -51,6 +51,50 @@ public class TankDataManager {
             "block_picker"
     );
 
+    /**
+     * Standalone CS&A tanks that store water in {@code tagStock} (not {@code tagWater}). Their
+     * capacity is a configurable world variable, so we never hardcode it — see {@link #stockFraction}.
+     */
+    private static final Set<String> WATER_STOCK_TANKS = Set.of(
+            "small_filling_tank", "medium_filling_tank", "large_filling_tank");
+
+    /** Standalone CS&A tanks that store fuel in {@code tagStock}. See {@link #WATER_STOCK_TANKS}. */
+    private static final Set<String> FUEL_STOCK_TANKS = Set.of(
+            "small_fueling_tank", "medium_fueling_tank", "large_fueling_tank");
+
+    /** Infinite creative water tank: it holds no {@code tagStock} and always reads as full. */
+    private static final String CREATIVE_FILLING_TANK = "creative_filling_tank";
+
+    /** Capacity of the jetpack/exoskeleton {@code tagFuel}/{@code tagWater} bars. */
+    private static final double TAG_LEVEL_CAPACITY = 1600.0;
+
+    /** Max width of a vanilla item durability bar; CS&A scales {@code tagStock} to this. */
+    private static final int ITEM_BAR_MAX = 13;
+
+    /** Registry path if {@code stack} is a CS&A item, otherwise {@code null}. */
+    private static String csaPath(ItemStack stack) {
+        if (stack.isEmpty()) return null;
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+        return CSA_NAMESPACE.equals(id.getNamespace()) ? id.getPath() : null;
+    }
+
+    private static double readTag(ItemStack stack, String key) {
+        return stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag().getDouble(key);
+    }
+
+    private static double clamp01(double v) {
+        return Math.max(0.0, Math.min(1.0, v));
+    }
+
+    /**
+     * Fill fraction (0..1) of a CS&A standalone tank. Read from the item's own capacity-aware bar
+     * ({@code getBarWidth}/13) so we honour CS&A's configurable tank capacities rather than guessing
+     * a maximum. Client-only (the bar reads the local player), which is fine for the HUD overlay.
+     */
+    private static double stockFraction(ItemStack stack) {
+        return clamp01(stack.getItem().getBarWidth(stack) / (double) ITEM_BAR_MAX);
+    }
+
     /** True if the stack is a known CS&A item whose registry path is in {@code knownItems}. */
     private static boolean isKnownCsaItem(ItemStack itemStack, Set<String> knownItems) {
         if (itemStack.isEmpty()) return false;
@@ -92,22 +136,35 @@ public class TankDataManager {
         return canItemStoreWater(chestplate);
     }
 
+    /** Raw stored fuel for {@code itemStack}: {@code tagStock} for fueling tanks, else {@code tagFuel}. */
     public static double getFuelLevel(ItemStack itemStack) {
-        int tagFuel = 0;
-        tagFuel = (int) itemStack
-                .getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY)
-                .copyTag()
-                .getDouble("tagFuel");
-        return tagFuel;
+        String path = csaPath(itemStack);
+        boolean stockTank = path != null && FUEL_STOCK_TANKS.contains(path);
+        return readTag(itemStack, stockTank ? "tagStock" : "tagFuel");
     }
 
+    /** Raw stored water for {@code itemStack}: {@code tagStock} for filling tanks, else {@code tagWater}. */
     public static double getWaterLevel(ItemStack itemStack) {
-        int tagFuel = 0;
-        tagFuel = (int) itemStack
-                .getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY)
-                .copyTag()
-                .getDouble("tagWater");
-        return tagFuel;
+        String path = csaPath(itemStack);
+        boolean stockTank = path != null && WATER_STOCK_TANKS.contains(path);
+        return readTag(itemStack, stockTank ? "tagStock" : "tagWater");
+    }
+
+    /** Fuel fill fraction (0..1) for the sprite bar. Tank items scale by their (configurable) capacity. */
+    public static double getFuelFraction(ItemStack itemStack) {
+        if (itemStack.isEmpty()) return 0.0;
+        String path = csaPath(itemStack);
+        if (path != null && FUEL_STOCK_TANKS.contains(path)) return stockFraction(itemStack);
+        return clamp01(readTag(itemStack, "tagFuel") / TAG_LEVEL_CAPACITY);
+    }
+
+    /** Water fill fraction (0..1) for the sprite bar. Tank items scale by their (configurable) capacity. */
+    public static double getWaterFraction(ItemStack itemStack) {
+        if (itemStack.isEmpty()) return 0.0;
+        String path = csaPath(itemStack);
+        if (CREATIVE_FILLING_TANK.equals(path)) return 1.0; // infinite tank: always full
+        if (path != null && WATER_STOCK_TANKS.contains(path)) return stockFraction(itemStack);
+        return clamp01(readTag(itemStack, "tagWater") / TAG_LEVEL_CAPACITY);
     }
 
 }


### PR DESCRIPTION
## Problem
Holding a filling/fueling tank (small/medium/large) or the creative filling tank showed an **empty** sprite even when the tank was full. The worn chest tank (jetpack) rendered fine.

## Cause
Confirmed by decompiling Create: Stuff 'N Additions:
- Jetpacks/exoskeletons store contents under `tagFuel`/`tagWater` — what we read.
- **Standalone tanks store their contents under `tagStock`** and only write `tagWater`/`tagFuel` transiently when transferring into a worn item. So `getDouble("tagWater")` returned 0.
- Their capacity is a **configurable world variable** (`smallTankCapacity` etc.), so a fixed max would mis-scale the bar.
- The creative tank stores no stock (infinite).

## Fix
- `getFuelLevel`/`getWaterLevel` read `tagStock` for the standalone tanks (fixes **text mode** too), `tagFuel`/`tagWater` otherwise.
- New `getFuelFraction`/`getWaterFraction` (0–1) for the sprite bar; tanks reuse CS&A's own capacity-aware `getBarWidth(stack)/13` so the bar honours the configured capacity. Creative tank reads as full.
- `TankSpriteOverlay` maps a 0–1 fraction → frame; removed the hardcoded `MAX_LEVEL`.

## Testing
Compiles against the real CS&A API. Not yet verified in-game — recommend hot-reloading with a full filling tank in hand before release.

## Out of scope
`creative_filling_tank` is listed in both the fuel and water capability sets (likely an original mistake; it's water-only). Harmless visually, left untouched.