### PR TITLE
feat: editor previews and positions the active overlay mode

### DIFF
--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayAnchor.java
@@ -16,16 +16,18 @@ public final class OverlayAnchor {
     private OverlayAnchor() {}
 
     /**
-     * Resolves the top-left anchor of the simplified overlay composite.
+     * Resolves the top-left anchor of an overlay's content box. Generic over the content: pass the
+     * sprite composite size or the tooltip box size, and {@code CUSTOM}/corner positions resolve the
+     * same way, so both overlays and the editor agree on a position.
      *
      * @param position the configured overlay position
      * @param guiW     GUI-scaled screen width
      * @param guiH     GUI-scaled screen height
-     * @param contentW rendered width of the whole composite in GUI pixels
-     * @param contentH rendered height of the whole composite in GUI pixels
+     * @param contentW rendered width of the content box in GUI pixels
+     * @param contentH rendered height of the content box in GUI pixels
      * @return {@code [x, y]} top-left anchor in GUI pixels
      */
-    public static int[] resolveSprite(OverlayPosition position, int guiW, int guiH, int contentW, int contentH) {
+    public static int[] resolve(OverlayPosition position, int guiW, int guiH, int contentW, int contentH) {
         return switch (position) {
             case TOP_LEFT -> new int[]{MARGIN, MARGIN};
             case TOP_RIGHT -> new int[]{guiW - contentW - MARGIN, MARGIN};

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/OverlayEditScreen.java
@@ -32,6 +32,11 @@ public class OverlayEditScreen extends Screen {
     private static final double MAX_SCALE = 5.0;
 
     private final TankSpriteOverlay previewOverlay = new TankSpriteOverlay();
+    private final TankTooltipOverlay previewTooltip = new TankTooltipOverlay();
+
+    // True when editing the detailed (text) overlay; false for the simplified sprite. The position
+    // config is shared, but the preview, sizing and controls follow whichever mode is active.
+    private boolean detailed;
 
     // What Save will persist: a preset enum, or CUSTOM once the overlay has been dragged.
     private OverlayPosition pendingPosition = OverlayPosition.TOP_LEFT;
@@ -55,6 +60,9 @@ public class OverlayEditScreen extends Screen {
 
     @Override
     protected void init() {
+        // Edit whichever overlay is currently active; the position config is shared between them.
+        detailed = !CommonConfig.isSimplifiedEnabled();
+
         // Remember the scale we opened with so Cancel/Escape can revert a live preview.
         originalScale = CommonConfig.getSpriteScaleFactor();
         committed = false;
@@ -63,7 +71,7 @@ public class OverlayEditScreen extends Screen {
         // Seed the working anchor from where the overlay currently renders, so it doesn't jump.
         Player player = this.minecraft != null ? this.minecraft.player : null;
         if (player != null) {
-            int[] anchor = TankSpriteOverlay.currentAnchor(player, this.width, this.height);
+            int[] anchor = currentAnchor(player);
             anchorX = anchor[0];
             anchorY = anchor[1];
         }
@@ -74,12 +82,14 @@ public class OverlayEditScreen extends Screen {
         int presetY = bottom - 24;
         int sliderY = presetY - 24;
 
-        // Scale slider (with a tooltip clarifying it stacks on top of Minecraft's GUI Scale).
-        ScaleSlider slider = new ScaleSlider(cx - 110, sliderY, 220, 20, originalScale);
-        slider.setTooltip(Tooltip.create(Component.literal(
-                "Adjusts the tank sprite size. The overlay already scales with Minecraft's "
-                        + "GUI Scale setting; this is an extra multiplier on top of that.")));
-        addRenderableWidget(slider);
+        // Scale slider only applies to the sprite; the detailed text view does not use it.
+        if (!detailed) {
+            ScaleSlider slider = new ScaleSlider(cx - 110, sliderY, 220, 20, originalScale);
+            slider.setTooltip(Tooltip.create(Component.literal(
+                    "Adjusts the tank sprite size. The overlay already scales with Minecraft's "
+                            + "GUI Scale setting; this is an extra multiplier on top of that.")));
+            addRenderableWidget(slider);
+        }
 
         // Preset reset buttons.
         int presetW = 78;
@@ -109,9 +119,9 @@ public class OverlayEditScreen extends Screen {
     private void applyPreset(OverlayPosition position) {
         pendingPosition = position;
         Player player = this.minecraft != null ? this.minecraft.player : null;
-        int w = player != null ? TankSpriteOverlay.compositeWidthPx(player) : 0;
-        int h = TankSpriteOverlay.compositeHeightPx();
-        int[] anchor = OverlayAnchor.resolveSprite(position, this.width, this.height, w, h);
+        int w = player != null ? contentW(player) : 0;
+        int h = player != null ? contentH(player) : 0;
+        int[] anchor = OverlayAnchor.resolve(position, this.width, this.height, w, h);
         anchorX = anchor[0];
         anchorY = anchor[1];
         clampAnchor();
@@ -141,13 +151,17 @@ public class OverlayEditScreen extends Screen {
         // The overlay preview.
         Player player = this.minecraft != null ? this.minecraft.player : null;
         if (player != null) {
-            int w = TankSpriteOverlay.compositeWidthPx(player);
-            int h = TankSpriteOverlay.compositeHeightPx();
+            int w = contentW(player);
+            int h = contentH(player);
 
             int border = dragging ? 0xFFFFE066 : 0x80FFFFFF;
             graphics.renderOutline(anchorX - 1, anchorY - 1, w + 2, h + 2, border);
 
-            previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player, PREVIEW_ITEM_Z);
+            if (detailed) {
+                previewTooltip.renderPreviewAt(graphics, anchorX, anchorY, player);
+            } else {
+                previewOverlay.renderCompositeAt(graphics, anchorX, anchorY, player, PREVIEW_ITEM_Z);
+            }
         }
 
         if (dragging) {
@@ -217,18 +231,34 @@ public class OverlayEditScreen extends Screen {
     private boolean isInsideOverlay(double mouseX, double mouseY) {
         Player player = this.minecraft != null ? this.minecraft.player : null;
         if (player == null) return false;
-        int w = TankSpriteOverlay.compositeWidthPx(player);
-        int h = TankSpriteOverlay.compositeHeightPx();
+        int w = contentW(player);
+        int h = contentH(player);
         return mouseX >= anchorX && mouseX <= anchorX + w && mouseY >= anchorY && mouseY <= anchorY + h;
     }
 
-    /** Keeps the composite fully on screen. */
+    /** Keeps the content box fully on screen. */
     private void clampAnchor() {
         Player player = this.minecraft != null ? this.minecraft.player : null;
-        int w = player != null ? TankSpriteOverlay.compositeWidthPx(player) : 0;
-        int h = TankSpriteOverlay.compositeHeightPx();
+        int w = player != null ? contentW(player) : 0;
+        int h = player != null ? contentH(player) : 0;
         anchorX = OverlayAnchor.clamp(anchorX, 0, Math.max(0, this.width - w));
         anchorY = OverlayAnchor.clamp(anchorY, 0, Math.max(0, this.height - h));
+    }
+
+    /** Width of the active overlay's content box in GUI pixels (sprite composite or tooltip box). */
+    private int contentW(Player player) {
+        return detailed ? TankTooltipOverlay.tooltipWidthPx(player) : TankSpriteOverlay.compositeWidthPx(player);
+    }
+
+    /** Height of the active overlay's content box in GUI pixels. */
+    private int contentH(Player player) {
+        return detailed ? TankTooltipOverlay.tooltipHeightPx(player) : TankSpriteOverlay.compositeHeightPx();
+    }
+
+    /** Where the active overlay currently anchors, so the editor opens without the preview jumping. */
+    private int[] currentAnchor(Player player) {
+        return detailed ? TankTooltipOverlay.currentAnchor(player, this.width, this.height)
+                        : TankSpriteOverlay.currentAnchor(player, this.width, this.height);
     }
 
     @Override

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankSpriteOverlay.java
@@ -67,7 +67,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
         }
 
         OverlayPosition position = CommonConfig.getOverlayPosition();
-        int[] anchor = OverlayAnchor.resolveSprite(position, graphics.guiWidth(), graphics.guiHeight(),
+        int[] anchor = OverlayAnchor.resolve(position, graphics.guiWidth(), graphics.guiHeight(),
                 compositeWidthPx(player), compositeHeightPx());
 
         renderCompositeAt(graphics, anchor[0], anchor[1], player);
@@ -211,7 +211,7 @@ public class TankSpriteOverlay implements LayeredDraw.Layer {
      * seed the drag position so opening it shows the overlay exactly where it already renders.
      */
     public static int[] currentAnchor(Player player, int guiW, int guiH) {
-        return OverlayAnchor.resolveSprite(CommonConfig.getOverlayPosition(), guiW, guiH,
+        return OverlayAnchor.resolve(CommonConfig.getOverlayPosition(), guiW, guiH,
                 compositeWidthPx(player), compositeHeightPx());
     }
 }

--- a/src/main/java/com/jopgood/cfwinfo/client/gui/TankTooltipOverlay.java
+++ b/src/main/java/com/jopgood/cfwinfo/client/gui/TankTooltipOverlay.java
@@ -73,6 +73,12 @@ public class TankTooltipOverlay implements LayeredDraw.Layer {
         renderDetailedTooltip(graphics, partialTicks, width, height, player);
     }
 
+    // Tooltip box padding around the text (matches the renderTooltip call in drawBox).
+    private static final int PAD_TOP = 6;
+    private static final int PAD_BOTTOM = 6;
+    private static final int PAD_LEFT = 3;
+    private static final int PAD_RIGHT = 12;
+
     private void renderDetailedTooltip(GuiGraphics graphics, float partialTicks, int width, int height, Player player) {
         CClient cfg = AllConfigs.client();
         PoseStack poseStack = graphics.pose();
@@ -80,24 +86,36 @@ public class TankTooltipOverlay implements LayeredDraw.Layer {
 
         hoverTicks++;
 
-        // Generate tooltip content
         List<Component> tooltip = TankGuiHelper.generateTooltipWithSpacing(player);
-
-        Minecraft mc = Minecraft.getInstance();
-
-        int tooltipTextWidth = 0;
-        for (FormattedText textLine : tooltip) {
-            int textLineWidth = mc.font.width(textLine);
-            if (textLineWidth > tooltipTextWidth)
-                tooltipTextWidth = textLineWidth;
-        }
-        int tooltipHeight = 8;
-        if (tooltip.size() > 1) {
-            tooltipHeight += 2; // gap between title lines and next lines
-            tooltipHeight += (tooltip.size() - 1) * 10;
+        if (tooltip.isEmpty()) {
+            poseStack.popPose();
+            return;
         }
 
-        // Colors with config integration
+        // Anchor the box through the shared resolver so a position chosen in the editor matches here.
+        int[] anchor = OverlayAnchor.resolve(CommonConfig.getOverlayPosition(), width, height,
+                boxWidth(tooltip), boxHeight(tooltip));
+
+        // Fade-in: slide in horizontally and ramp alpha.
+        float fadeSpeed = 24.0f;
+        float fade = Mth.clamp((hoverTicks + partialTicks) / fadeSpeed, 0, 1);
+        if (fade < 1) {
+            poseStack.translate(
+                    Math.pow(1 - fade, 3) * Math.signum(cfg.overlayOffsetX.get() + .5f) * 8, 0, 0);
+        }
+
+        drawBox(graphics, tooltip, anchor[0], anchor[1], fade);
+
+        poseStack.popPose();
+    }
+
+    /**
+     * Draws the tooltip box (background, border, text, goggles icon) with its top-left at the given
+     * box anchor, scaled by {@code fade} (1 = fully opaque). Shared by the live HUD and the editor.
+     */
+    private void drawBox(GuiGraphics graphics, List<Component> tooltip, int boxX, int boxY, float fade) {
+        CClient cfg = AllConfigs.client();
+
         Boolean useCustom = cfg.overlayCustomColor.get();
         Color tooltipBackground = new Color(0xf0100010, true);
         Color colorBackground = useCustom ? new Color(cfg.overlayBackgroundColor.get())
@@ -107,74 +125,78 @@ public class TankTooltipOverlay implements LayeredDraw.Layer {
         Color colorBorderBot = useCustom ? new Color(cfg.overlayBorderColorBot.get())
                 : new Color(0x5028007f, true);
 
-        // Apply opacity from our config
-        float opacityMultiplier = CommonConfig.getOverlayOpacity() / 100.0f;
-        colorBackground.scaleAlpha(opacityMultiplier);
-        colorBorderTop.scaleAlpha(opacityMultiplier);
-        colorBorderBot.scaleAlpha(opacityMultiplier);
+        float alpha = (CommonConfig.getOverlayOpacity() / 100.0f) * fade;
+        colorBackground.scaleAlpha(alpha);
+        colorBorderTop.scaleAlpha(alpha);
+        colorBorderBot.scaleAlpha(alpha);
 
-        // Position calculation based on config - properly sized for tooltips
-        int padding = 20;
-        int posX, posY;
-        switch (CommonConfig.getOverlayPosition()) {
-            case TOP_RIGHT:
-                posX = width - tooltipTextWidth - padding;
-                posY = padding;
-                break;
-            case BOTTOM_LEFT:
-                posX = padding;
-                posY = height - tooltipHeight - padding;
-                break;
-            case BOTTOM_RIGHT:
-                posX = width - tooltipTextWidth - padding;
-                posY = height - tooltipHeight - padding;
-                break;
-            case CUSTOM:
-                // Free position dragged by the player; clamp so the tooltip stays on screen.
-                posX = OverlayAnchor.clamp(CommonConfig.getCustomX(), 0, Math.max(0, width - tooltipTextWidth));
-                posY = OverlayAnchor.clamp(CommonConfig.getCustomY(), 0, Math.max(0, height - tooltipHeight));
-                break;
-            case TOP_LEFT:
-            default:
-                posX = padding;
-                posY = padding;
-                break;
-        }
+        // The box extends PAD_LEFT/PAD_TOP beyond the text origin, so offset the text inward.
+        int posX = boxX + PAD_LEFT;
+        int posY = boxY + PAD_TOP;
 
-        // Fade Effect using config fade speed
-        float fadeSpeed = (float) (24.0);
-        float fade = Mth.clamp((hoverTicks + partialTicks) / fadeSpeed, 0, 1);
-        if (fade < 1) {
-            poseStack.translate(
-                    Math.pow(1 - fade, 3) * Math.signum(cfg.overlayOffsetX.get() + .5f) * 8,
-                    0,
-                    0
-            );
-            colorBackground.scaleAlpha(fade);
-            colorBorderTop.scaleAlpha(fade);
-            colorBorderBot.scaleAlpha(fade);
-        }
-
-        // Render tooltip background using Create's styling
         PositionedTooltipRenderer.renderTooltip(
-                graphics,
-                tooltip,
-                posX,
-                posY,
-                colorBackground.getRGB(),
-                colorBorderTop.getRGB(),
-                colorBorderBot.getRGB(),
-                6,
-                6,
-                3,
-                12);
+                graphics, tooltip, posX, posY,
+                colorBackground.getRGB(), colorBorderTop.getRGB(), colorBorderBot.getRGB(),
+                PAD_TOP, PAD_BOTTOM, PAD_LEFT, PAD_RIGHT);
 
-        // Render goggles icon
         ItemStack item = AllItems.GOGGLES.asStack();
         GuiGameElement.of(item)
-                .at(posX - 2, posY - 4, 450)  // Small offset from tooltip start
+                .at(posX - 2, posY - 4, 450) // Small offset from tooltip start
                 .render(graphics);
+    }
 
-        poseStack.popPose();
+    /**
+     * Renders a static (full-opacity) tooltip preview with its top-left at {@code (boxX, boxY)}.
+     * Used by the overlay editor so the detailed view can be positioned with a live preview.
+     */
+    public void renderPreviewAt(GuiGraphics graphics, int boxX, int boxY, Player player) {
+        List<Component> tooltip = TankGuiHelper.generateTooltipWithSpacing(player);
+        if (tooltip.isEmpty()) {
+            return;
+        }
+        drawBox(graphics, tooltip, boxX, boxY, 1.0f);
+    }
+
+    private static int textWidth(List<Component> tooltip) {
+        Minecraft mc = Minecraft.getInstance();
+        int w = 0;
+        for (FormattedText line : tooltip) {
+            w = Math.max(w, mc.font.width(line));
+        }
+        return w;
+    }
+
+    private static int textHeight(List<Component> tooltip) {
+        int h = 8;
+        if (tooltip.size() > 1) {
+            h += 2; // gap between title lines and next lines
+            h += (tooltip.size() - 1) * 10;
+        }
+        return h;
+    }
+
+    private static int boxWidth(List<Component> tooltip) {
+        return textWidth(tooltip) + PAD_LEFT + PAD_RIGHT;
+    }
+
+    private static int boxHeight(List<Component> tooltip) {
+        return textHeight(tooltip) + PAD_TOP + PAD_BOTTOM;
+    }
+
+    /** Rendered width of the tooltip box in GUI pixels (for the editor's hit-test / clamping). */
+    public static int tooltipWidthPx(Player player) {
+        return boxWidth(TankGuiHelper.generateTooltipWithSpacing(player));
+    }
+
+    /** Rendered height of the tooltip box in GUI pixels. */
+    public static int tooltipHeightPx(Player player) {
+        return boxHeight(TankGuiHelper.generateTooltipWithSpacing(player));
+    }
+
+    /** Top-left box anchor for the configured position, so the editor opens where the HUD renders. */
+    public static int[] currentAnchor(Player player, int guiW, int guiH) {
+        List<Component> tooltip = TankGuiHelper.generateTooltipWithSpacing(player);
+        return OverlayAnchor.resolve(CommonConfig.getOverlayPosition(), guiW, guiH,
+                boxWidth(tooltip), boxHeight(tooltip));
     }
 }


### PR DESCRIPTION
## Problem
The overlay position config is **shared** between the simplified sprite and the detailed (text) overlay, but the position editor only ever previewed the *sprite*. So the detailed tooltip could only be repositioned blind — by dragging the sprite in simplified mode and switching back.

## Approach (Option A: preview the active mode, shared position)
The editor now follows whichever overlay mode is active (`isSimplifiedEnabled()`):
- **Detailed mode**: previews, sizes, hit-tests and clamps the *tooltip box*, and hides the sprite-only scale slider.
- **Simplified mode**: unchanged.

One shared position is kept — no new config.

## Changes
- `OverlayEditScreen`: mode-aware preview / sizing / clamping; scale slider only in sprite mode.
- `TankTooltipOverlay`: exposes `tooltipWidthPx/HeightPx`, `currentAnchor`, and a static `renderPreviewAt(x, y)`; its live render now anchors through the shared `OverlayAnchor` (box top-left semantics, MARGIN-based corners) so an editor-chosen position matches the HUD exactly. Live render and editor preview share one `drawBox`.
- `OverlayAnchor.resolveSprite` → `resolve` (it's generic over the content box; both overlays use it).

## Behaviour notes
- The detailed tooltip's corner presets now use the shared `MARGIN` (10px) instead of the old hardcoded 20px, and `CUSTOM` is now the box top-left rather than the text origin — a small, intentional shift for sprite/tooltip consistency.

## Testing
Compiles against the real API. Not yet verified in-game — recommend opening the editor in **detailed mode** (no goggles needed to *position*, but the live HUD needs goggles) to confirm the tooltip previews and saves correctly.