### PR TITLE
release: 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-06-04
+### Added
+- **Position the detailed overlay, not just the sprite**: the in-game overlay editor (keybind `O`) now previews and positions whichever view you are using. In detailed (text) mode it shows the real tooltip while you place it, instead of only ever previewing the simplified sprite. The sprite-only scale slider is hidden in detailed mode.
+
+### Fixed
+- **Held filling/fueling tanks now show their real level**: standalone Create: Stuff 'N Additions tanks (small/medium/large filling and fueling tanks, and the creative filling tank) store their contents differently from jetpacks, so the overlay previously drew them as empty even when full. They now read correctly in both the sprite and text overlays, scaled to each tank's (configurable) capacity. The creative tank reads as full.
+
+### Changed
+- **License metadata corrected to MIT** to match `LICENSE.txt`; the build previously still declared the template default "All Rights Reserved".
+
 ## [1.8.0] - 2026-06-03
 ### Added
 - **Drag-to-position overlay editor**: a new keybind (default `O`) opens an in-game editor where you can drag the overlay anywhere on screen. The preview matches the live HUD exactly, and the controls hide while dragging for an unobstructed view.
@@ -101,6 +111,10 @@ Previous versions were built for Minecraft Forge. See individual release files i
 
 **Note**: For detailed release notes with user-friendly descriptions, see the corresponding files in `docs/releases/`.
 
-[Unreleased]: https://github.com/Jopgood/Create-Information-Addon/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/Jopgood/Create-Information-Addon/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/Jopgood/Create-Information-Addon/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/Jopgood/Create-Information-Addon/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/Jopgood/Create-Information-Addon/compare/v1.6.1...v1.7.0
+[1.6.1]: https://github.com/Jopgood/Create-Information-Addon/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/Jopgood/Create-Information-Addon/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/Jopgood/Create-Information-Addon/releases/tag/v1.5.0

--- a/docs/releases/v1.9.0.md
+++ b/docs/releases/v1.9.0.md
@@ -1,0 +1,38 @@
+# 🎯 Release v1.9.0 - Handheld Tanks Read Right, and a Smarter Position Editor
+
+> **Highlights**: Held filling/fueling tanks now show their actual level on the HUD, and the position editor can finally place the *detailed* overlay too — not just the sprite.
+
+## ✨ What's New
+
+### 📝 Position the Detailed Overlay
+- The **Edit Overlay Position** keybind (default `O`) now previews **whichever overlay you're using**.
+- In **detailed (text) mode**, the editor shows the real tooltip while you drag it, so what you see is what you get — previously you could only ever preview the simplified sprite.
+- The tank **scale slider** only appears in simplified mode now, since it doesn't apply to the text view.
+- Position is still shared between both views, so setting it once carries across.
+
+## 🔧 Fixes
+
+### 🪣 Held Tanks Now Show Their Real Level
+- Standalone Create: Stuff 'N Additions tanks — the **small / medium / large filling and fueling tanks** and the **creative filling tank** — used to display as empty even when full.
+- They store their contents differently from the jetpacks/exoskeletons, so the overlay was reading the wrong value. They now read correctly in **both** the sprite and text overlays.
+- The level is scaled to each tank's capacity (including CS&A's configurable capacities), and the **creative filling tank** always reads as full.
+
+## 🔄 Under the Hood
+- License metadata corrected to **MIT** to match `LICENSE.txt`.
+
+## 🔄 Backward Compatibility
+
+✅ **Existing configs keep working** — your saved overlay position and settings are unchanged.
+✅ **Same Minecraft version** — still Minecraft 1.21.1 / NeoForge.
+
+## 📥 Installation
+
+1. Download the latest `.jar` file from this release
+2. Place it in your `mods` folder
+3. Launch Minecraft with NeoForge
+
+---
+
+**Requirements**: Minecraft 1.21.1 | NeoForge 21.1.233+ | Create 6.0.11+
+
+**Compatibility**: Works with Create: Stuff & Additions and other Create-compatible tank items

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ mod_name=Create: Fuel & Water Information
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.8.0
+mod_version=1.9.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html


### PR DESCRIPTION
Release prep for **v1.9.0**. After merge, push the `v1.9.0` tag to trigger the publish workflow (GitHub Release + CurseForge + Modrinth).

## Included since 1.8.0
- **Feature** (#13): the overlay editor now previews/positions the detailed text overlay, not just the sprite.
- **Fix** (#12): standalone filling/fueling/creative tanks read their level from `tagStock`, so held tanks no longer show empty when full.
- **Chore** (#11): license metadata corrected to MIT.

## This PR
- `mod_version` 1.8.0 → 1.9.0
- `CHANGELOG.md`: new `[1.9.0]` section + refreshed compare links
- `docs/releases/v1.9.0.md`: player-facing notes (becomes the release/CurseForge/Modrinth changelog body)

The `release-readiness` CI gate should pass (version has both a CHANGELOG entry and a docs note). Build produces `cfwinfo-1.9.0.jar` locally.