### PR TITLE
ci: dedupe PR runs and bump actions off Node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,25 +1,35 @@
 name: CI
 
-on: [push, pull_request]
+# Run on PRs (covers branches) and on pushes to main (covers merges). A branch with an open
+# PR no longer double-runs, since the push event is scoped to main.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel an in-progress run if the same ref is pushed again.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle
         run: ./gradlew build
@@ -33,7 +43,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify release notes exist for current mod_version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       # Guard against a tag that doesn't match the version in gradle.properties.
       - name: Resolve and verify version


### PR DESCRIPTION
Two CI tidy-ups.

## 1. No more double runs
`build.yml` used `on: [push, pull_request]`, so a branch with an open PR triggered two CI runs (one per event). Now:

```yaml
on:
  push:
    branches: [main]
  pull_request:
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

- PR branch → one run (pull_request)
- merge to main → one run (push)
- concurrency cancels superseded in-progress runs

Tradeoff: pushing a branch with **no** PR yet won't run CI until the PR is opened. `release-readiness`'s `if:` condition is unchanged.

## 2. Off the deprecated Node 20 runtime
Bumped in **both** workflows: `checkout@v4→v6`, `setup-java@v4→v5`, `setup-gradle@v4→v6`. `mc-publish` stays at `v3.3` (its latest release; its Node 20 notice clears only when upstream updates).

> Note: this PR itself will still double-run once, since the dedupe only takes effect after it merges.