### PR TITLE
docs: scope the 1.20.1 Forge port

### DIFF
--- a/docs/ports/1.20.1-port-scope.md
+++ b/docs/ports/1.20.1-port-scope.md
@@ -1,0 +1,91 @@
+# 1.20.1 Forge port — scope
+
+Concrete task breakdown for backporting `cfwinfo` to **Minecraft 1.20.1 / Forge / Java 17** on a
+`mc/1.20.1` branch (see `docs/MULTIVERSION.md` for the why and the structure decision).
+
+**Spike status:** NBT read approach is confirmed feasible — CSA 1.20.1 tanks use the same
+`tagStock` / `tagWater` / `tagFuel` keys, read via old-style `ItemStack.getOrCreateTag()` (no Data
+Components). Toolchain (workstream A) remains the largest unknown.
+
+## Strategy
+
+- **Same feature set, same version number** as 1.21.1 (a `1.x.y` release is built for each MC).
+- **Phasing decision (open):** ship a v1 with just the overlays (sprite + text), and port the
+  drag-to-position **editor** (1.8.0 feature) as a fast-follow? The editor touches the most
+  version-sensitive GUI APIs, so deferring it de-risks the first 1.20.1 release. Recommended: yes,
+  phase it.
+
+## Workstreams (ordered by dependency; sizes are rough)
+
+### A. Build & toolchain — **L, do first, riskiest**
+- `build.gradle`: replace `net.neoforged.moddev` with **ForgeGradle** (or MDG legacy), Java toolchain
+  17, official + Parchment 1.20.1 mappings.
+- `gradle.properties`: `minecraft_version=1.20.1`, Forge version (47.x), `create_version` = Create
+  **0.5.1** (Forge) from `maven.createmod.net`, CSA 1.20.1 Curse file id, and 1.20.1-compatible
+  Flywheel / Registrate / JEI.
+- **Verify:** how Ponder/Flywheel are distributed for Create 0.5.1 (largely bundled — the
+  `transitive = false` + explicit-deps setup from 1.21.1 likely changes or goes away).
+- Exit criteria: `./gradlew build` resolves Create + CSA 1.20.1 and produces a jar.
+
+### B. Mod bootstrap & metadata — **S/M**
+- `CfwInfo` / `CfwInfoClient`: Forge `@Mod` lifecycle (`FMLJavaModLoadingContext`, mod/forge buses).
+- `src/main/templates/META-INF/neoforge.mods.toml` → **`mods.toml`** (Forge format): `loaderVersion`
+  for Forge `[47,)`, Create + CSA dependency entries, MIT license.
+- `pack.mcmeta` `pack_format` → 15 (1.20.1).
+
+### C. Config — **S**
+- `CommonConfig`: `ModConfigSpec` → **`ForgeConfigSpec`** (`net.minecraftforge.common`); registration
+  via `ModLoadingContext.get().registerConfig(...)`. The `safeGet`/`safeSet` load-guard pattern and
+  all accessors carry over unchanged in shape.
+
+### D. Data read layer — **S (confirmed by spike)**
+- `TankDataManager`: swap the component read
+  `stack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag()` →
+  `stack.getTag()` (nullable) / `getOrCreateTag()`. Keys, the `tagStock` standalone-tank logic, and
+  the capacity-aware `getBarWidth` fraction strategy are all unchanged. `BuiltInRegistries.ITEM`
+  exists on 1.20.1.
+
+### E. HUD overlays — **M/L**
+- 1.20.1 Forge has no `LayeredDraw.Layer` / `RegisterGuiLayersEvent`. Reimplement both overlays as
+  **`IGuiOverlay`** registered via `RegisterGuiOverlaysEvent` (render signature
+  `(ForgeGui, GuiGraphics, partialTick, width, height)`).
+- `GuiGraphics.blit` overloads differ slightly on 1.20.1 — re-check the sprite-sheet blit args in
+  `TankSpriteOverlay`.
+- `ClientSetup`: overlay + keybind registration moves to the Forge events; `KeyBinding` swaps the
+  NeoForge `Lazy` for a standard supplier. `RegisterKeyMappingsEvent` exists on both.
+
+### F. Editor screen — **M (candidate to defer to phase 2)**
+- `OverlayEditScreen`: `Screen` API mostly compatible, but `renderBackground` signature differs
+  (1.20.1: `renderBackground(GuiGraphics)`), and double-check `Button.builder` / `AbstractSliderButton`
+  / `Tooltip.create`. `OverlayAnchor` is pure logic and ports as-is.
+
+### G. Create / catnip API reconciliation — **M, cross-cutting, biggest unknown**
+- **catnip does not exist on Create 0.5.1**: `net.createmod.catnip.gui.element.GuiGameElement` and
+  `net.createmod.catnip.theme.Color` move to Create's own packages
+  (`com.simibubi.create.foundation.gui.element.GuiGameElement`, Create's `Color`). Update imports in
+  `TankSpriteOverlay` / `TankTooltipOverlay` / `PositionedTooltipRenderer`.
+- **Verify:** `AllConfigs.client()` on Create 0.5.1 still exposes the tooltip fields used by
+  `TankTooltipOverlay` (`overlayCustomColor`, `overlayBackgroundColor`, `overlayBorderColorTop/Bot`,
+  `overlayOffsetX`). Field names may differ — confirm against the 0.5.1 jar.
+- `GogglesItem` / `AllItems.GOGGLES` exist; confirm package paths.
+
+### H. CI / release wiring — **S (per MULTIVERSION.md)**
+- On `mc/1.20.1`: own `build.yml` (Java 17) + `release.yml` with `loaders: forge`,
+  `game-versions: '1.20.1'`, jar/tag carrying `+mc1.20.1`, publishing into the same CurseForge/Modrinth
+  listings. `release-readiness` gate stays per-branch.
+
+### Verification
+- In-game on a 1.20.1 Forge instance with Create 0.5.1 + CSA: worn jetpack, held filling/fueling/
+  creative tanks, both overlay modes, and (if ported) the editor.
+
+## Suggested order
+
+A → B → (C, D in parallel) → **G** (reconcile imports/fields) → E → F → H, verifying in-game as each
+GUI piece lands. G is sequenced before E/F because the import/field reality it uncovers shapes both.
+
+## Open decisions
+
+1. **Defer the editor (F) to a phase-2 release?** (Recommended — smaller, safer first 1.20.1 ship.)
+2. **ForgeGradle vs MDG-legacy** for the build (A) — pick during the toolchain spike.
+3. **NeoForge-1.20.1 instead of Forge?** Rejected for now: CSA is Forge-only on 1.20.1, so matching
+   Forge is the safe path (revisit only if a NeoForge-1.20.1 CSA appears).


### PR DESCRIPTION
Concrete, file-by-file breakdown for the 1.20.1 Forge backport (builds on the merged multi-version plan).

## Records the spike result
NBT read approach **confirmed feasible**: CSA 1.20.1 tanks use the same `tagStock`/`tagWater`/`tagFuel` keys via old-style `getOrCreateTag()` (no Data Components).

## Workstreams (sized + ordered)
- **A. Build/toolchain** (L, first, riskiest) — ForgeGradle, Java 17, Create 0.5.1 + CSA 1.20.1 deps
- **B. Bootstrap & metadata** — Forge `@Mod`, `mods.toml`, pack_format 15
- **C. Config** — `ModConfigSpec` → `ForgeConfigSpec`
- **D. Read layer** — Data Components → old NBT (confirmed small)
- **E. HUD overlays** — `LayeredDraw` → `IGuiOverlay`
- **F. Editor** — `Screen` API diffs (candidate to defer to phase 2)
- **G. Create/catnip reconciliation** (biggest unknown) — catnip absent on 0.5.1; verify `AllConfigs` tooltip fields
- **H. CI/release** — per-branch `release.yml`, `+mc1.20.1` artifacts

## Open decisions called out
1. Defer the editor to phase 2? (recommended)
2. ForgeGradle vs MDG-legacy (decide in toolchain spike)
3. Forge vs NeoForge-1.20.1 (Forge, to match CSA)

Docs-only; no code change. Next concrete action would be the toolchain spike (workstream A).