### PR TITLE
docs: 1.20.1 toolchain spike findings (Create 6.x, Forge)

### DIFF
--- a/docs/ports/1.20.1-port-scope.md
+++ b/docs/ports/1.20.1-port-scope.md
@@ -3,13 +3,24 @@
 Concrete task breakdown for backporting `cfwinfo` to **Minecraft 1.20.1 / Forge / Java 17** on a
 `mc/1.20.1` branch (see `docs/MULTIVERSION.md` for the why and the structure decision).
 
-**Spike status:** NBT read approach is confirmed feasible — CSA 1.20.1 tanks use the same
-`tagStock` / `tagWater` / `tagFuel` keys, read via old-style `ItemStack.getOrCreateTag()` (no Data
-Components). Toolchain (workstream A) remains the largest unknown.
+**Spike status (updated — supersedes the original 0.5.1 assumption):**
+- **NBT read** confirmed feasible — CSA 1.20.1 tanks use the same `tagStock`/`tagWater`/`tagFuel`
+  keys, read via old-style `ItemStack.getOrCreateTag()` (no Data Components).
+- **Loader settled: Forge.** Create 6.x for 1.20.1 ships `mods.toml`/`javafml`/`[47,)`; CSA is Forge;
+  there is no NeoForge Create on 1.20.1.
+- **Create target decided: 6.x** (not 0.5.1). The modern stack is published for 1.20.1 Forge:
+  `com.simibubi.create:create-1.20.1:6.0.8-291` (an `-all` jar) and **catnip** as
+  `net.createmod.catnip:Catnip-Forge-1.20.1`. So the Create-facing API is the **same 6.x our 1.21.1
+  code already uses** — workstream **G largely dissolves** (no pre-catnip rewrite).
+- Remaining unknowns are the **loader/MC-version deltas** (workstreams A/B/C/D/E) and exact transitive
+  versions (flywheel/ponder/registrate, CSA Curse file id) — to be nailed by standing up the build.
 
 ## Strategy
 
 - **Same feature set, same version number** as 1.21.1 (a `1.x.y` release is built for each MC).
+- **Create target: 6.x on 1.20.1 Forge** — keeps the Create/catnip API shared with `main`, so the port
+  is mostly a loader + MC-version port, not a Create-API rewrite. (Trade-off: targets the 1.20.1
+  audience on newer Create rather than the classic 0.5.1 crowd.)
 - **Phasing decision (open):** ship a v1 with just the overlays (sprite + text), and port the
   drag-to-position **editor** (1.8.0 feature) as a fast-follow? The editor touches the most
   version-sensitive GUI APIs, so deferring it de-risks the first 1.20.1 release. Recommended: yes,
@@ -18,14 +29,19 @@ Components). Toolchain (workstream A) remains the largest unknown.
 ## Workstreams (ordered by dependency; sizes are rough)
 
 ### A. Build & toolchain — **L, do first, riskiest**
-- `build.gradle`: replace `net.neoforged.moddev` with **ForgeGradle** (or MDG legacy), Java toolchain
-  17, official + Parchment 1.20.1 mappings.
-- `gradle.properties`: `minecraft_version=1.20.1`, Forge version (47.x), `create_version` = Create
-  **0.5.1** (Forge) from `maven.createmod.net`, CSA 1.20.1 Curse file id, and 1.20.1-compatible
-  Flywheel / Registrate / JEI.
-- **Verify:** how Ponder/Flywheel are distributed for Create 0.5.1 (largely bundled — the
-  `transitive = false` + explicit-deps setup from 1.21.1 likely changes or goes away).
-- Exit criteria: `./gradlew build` resolves Create + CSA 1.20.1 and produces a jar.
+- `build.gradle`: replace `net.neoforged.moddev` with **ForgeGradle** or **MDG legacy** (decide during
+  setup), Java toolchain 17, official + Parchment 1.20.1 mappings.
+- `gradle.properties` — verified coordinates so far:
+  - Forge `1.20.1-47.4.20` (latest 47.x)
+  - Create `com.simibubi.create:create-1.20.1:6.0.8-291` (the `-all` jar)
+  - catnip `net.createmod.catnip:Catnip-Forge-1.20.1:<ver>` (resolve exact version)
+  - **still to pin:** Flywheel + Ponder (1.20.1 6.x coordinates), Registrate (1.20.1), JEI (1.20.1),
+    and the **CSA 1.20.1 Curse file id** (Modrinth version is `2.1.2`)
+- **Verify:** the `transitive = false` + explicit-deps pattern from 1.21.1 — replicate it against the
+  1.20.1 6.x stack (Create `-all` jar may already bundle some of Ponder/Flywheel).
+- Exit criteria: `./gradlew build` resolves Create 6.x + catnip + CSA 1.20.1 and produces a jar.
+- **Shortcut:** crib the dependency block from an existing Create-6.x-**1.20.1** addon's `build.gradle`
+  rather than deriving it from scratch.
 
 ### B. Mod bootstrap & metadata — **S/M**
 - `CfwInfo` / `CfwInfoClient`: Forge `@Mod` lifecycle (`FMLJavaModLoadingContext`, mod/forge buses).
@@ -59,15 +75,13 @@ Components). Toolchain (workstream A) remains the largest unknown.
   (1.20.1: `renderBackground(GuiGraphics)`), and double-check `Button.builder` / `AbstractSliderButton`
   / `Tooltip.create`. `OverlayAnchor` is pure logic and ports as-is.
 
-### G. Create / catnip API reconciliation — **M, cross-cutting, biggest unknown**
-- **catnip does not exist on Create 0.5.1**: `net.createmod.catnip.gui.element.GuiGameElement` and
-  `net.createmod.catnip.theme.Color` move to Create's own packages
-  (`com.simibubi.create.foundation.gui.element.GuiGameElement`, Create's `Color`). Update imports in
-  `TankSpriteOverlay` / `TankTooltipOverlay` / `PositionedTooltipRenderer`.
-- **Verify:** `AllConfigs.client()` on Create 0.5.1 still exposes the tooltip fields used by
-  `TankTooltipOverlay` (`overlayCustomColor`, `overlayBackgroundColor`, `overlayBorderColorTop/Bot`,
-  `overlayOffsetX`). Field names may differ — confirm against the 0.5.1 jar.
-- `GogglesItem` / `AllItems.GOGGLES` exist; confirm package paths.
+### G. Create / catnip API reconciliation — **S, mostly dissolved (was the biggest unknown)**
+- Because we target **Create 6.x** (not 0.5.1), catnip is present (`Catnip-Forge-1.20.1`) and the
+  catnip imports (`net.createmod.catnip...GuiGameElement` / `Color`) are the **same as 1.21.1**.
+- Only check for **minor 6.x-line deltas** between the 1.20.1 and 1.21.1 Create builds: confirm
+  `AllConfigs.client()` exposes the same tooltip fields (`overlayCustomColor`,
+  `overlayBackgroundColor`, `overlayBorderColorTop/Bot`, `overlayOffsetX`) and that
+  `GogglesItem` / `AllItems.GOGGLES` packages match. Expected to be near-identical.
 
 ### H. CI / release wiring — **S (per MULTIVERSION.md)**
 - On `mc/1.20.1`: own `build.yml` (Java 17) + `release.yml` with `loaders: forge`,
@@ -75,17 +89,17 @@ Components). Toolchain (workstream A) remains the largest unknown.
   listings. `release-readiness` gate stays per-branch.
 
 ### Verification
-- In-game on a 1.20.1 Forge instance with Create 0.5.1 + CSA: worn jetpack, held filling/fueling/
+- In-game on a 1.20.1 Forge instance with Create 6.x + CSA: worn jetpack, held filling/fueling/
   creative tanks, both overlay modes, and (if ported) the editor.
 
 ## Suggested order
 
-A → B → (C, D in parallel) → **G** (reconcile imports/fields) → E → F → H, verifying in-game as each
-GUI piece lands. G is sequenced before E/F because the import/field reality it uncovers shapes both.
+A → B → (C, D in parallel) → E → F → H, verifying in-game as each GUI piece lands. With workstream G
+now minimal (shared Create 6.x API), the critical path is the loader/MC-version work (A/B/C/D/E).
 
 ## Open decisions
 
 1. **Defer the editor (F) to a phase-2 release?** (Recommended — smaller, safer first 1.20.1 ship.)
 2. **ForgeGradle vs MDG-legacy** for the build (A) — pick during the toolchain spike.
-3. **NeoForge-1.20.1 instead of Forge?** Rejected for now: CSA is Forge-only on 1.20.1, so matching
-   Forge is the safe path (revisit only if a NeoForge-1.20.1 CSA appears).
+3. ~~NeoForge-1.20.1 instead of Forge?~~ **Settled: Forge.** Create 6.x on 1.20.1 is a Forge build and
+   CSA is Forge; no NeoForge Create exists on 1.20.1.


### PR DESCRIPTION
Updates the port scope with what the toolchain spike (workstream A) actually found — and it's good news.

## Key corrections to the original scope
- **Loader settled: Forge.** `create-1.20.1` 6.x ships `mods.toml`/`javafml`/`[47,)` (a Forge build); CSA is Forge; no NeoForge Create exists on 1.20.1. Open decision #3 resolved.
- **Create target: 6.x, not 0.5.1.** The modern stack is published for 1.20.1 Forge:
  - `com.simibubi.create:create-1.20.1:6.0.8-291` (`-all` jar)
  - `net.createmod.catnip:Catnip-Forge-1.20.1`
- **Workstream G shrinks from L → S.** Since the Create/catnip API matches 1.21.1, there's no pre-catnip rewrite — the port is now primarily a **loader/MC-version** port (Forge events, `ForgeConfigSpec`, old-NBT read layer, `IGuiOverlay`).

## Verified coordinates recorded
Forge `1.20.1-47.4.20`, Create `6.0.8-291`, catnip `Catnip-Forge-1.20.1`. Remaining lookups noted: Flywheel/Ponder/Registrate/JEI for 1.20.1, and the CSA 1.20.1 Curse file id.

Docs-only. Next concrete step: stand up the Forge 1.20.1 build (ForgeGradle or MDG-legacy) on `mc/1.20.1` and resolve the remaining coordinates.